### PR TITLE
Fix broken static builds

### DIFF
--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -165,7 +165,7 @@ fn fetch() -> io::Result<()> {
         .arg("clone")
         .arg("--depth=1")
         .arg("-b")
-        .arg(format!("release/{}", ffmpeg_version()))
+        .arg(format!("n{}", ffmpeg_version()))
         .arg("https://github.com/FFmpeg/FFmpeg")
         .arg(&clone_dest_dir)
         .status()?;


### PR DESCRIPTION
The ffmpeg project changed their branch/tag naming structure. There is now a branch for the major.minor version using the old naming scheme (`release/{major}.{minor}`) and a tag called `n{major}.{minor}[.{patch}]`.

This change broke the static builds which checked out no-longer-existing ffmpeg branches with their old name.