### PR TITLE
Fix build against clang 16

### DIFF
--- a/ffmpeg-sys-the-third/Cargo.toml
+++ b/ffmpeg-sys-the-third/Cargo.toml
@@ -26,7 +26,7 @@ libc = "0.2"
 num_cpus = "1.11"
 cc = "1.0"
 pkg-config = "0.3"
-bindgen = { version = "0.61", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.64", default-features = false, features = ["runtime"] }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -1169,9 +1169,9 @@ fn main() {
         .parse_callbacks(Box::new(Callbacks));
 
     if env::var("CARGO_FEATURE_NON_EXHAUSTIVE_ENUMS").is_ok() {
-        builder = builder.rustified_non_exhaustive_enum("*");
+        builder = builder.rustified_non_exhaustive_enum(".*");
     } else {
-        builder = builder.rustified_enum("*");
+        builder = builder.rustified_enum(".*");
     }
 
     // The input headers we would like to generate


### PR DESCRIPTION
This patch upgrades the `bindgen` dependency to version 0.64 which includes a fix for an upstream issue broken builds when building w/ clang 16 or newer \[0\].

The use of a wildcard `*` was removed in bindgen 0.62 \[1\], code has been updated to use the regex approach instead to continue working.

\[0]: https://github.com/rust-lang/rust-bindgen/pull/2316
\[1]: https://github.com/rust-lang/rust-bindgen/issues/2373