### PR TITLE
Add macOS package manager search paths for pkg-config

### DIFF
--- a/examples/chapters.rs
+++ b/examples/chapters.rs
@@ -16,7 +16,7 @@ fn main() {
                 println!("\tend: {}", chapter.end());
 
                 for (k, v) in chapter.metadata().iter() {
-                    println!("\t{}: {}", k, v);
+                    println!("\t{k}: {v}");
                 }
             }
 
@@ -49,11 +49,11 @@ fn main() {
                 println!("\tstart: {}", chapter.start());
                 println!("\tend: {}", chapter.end());
                 for (k, v) in chapter.metadata().iter() {
-                    println!("\t{}: {}", k, v);
+                    println!("\t{k}: {v}");
                 }
             }
         }
 
-        Err(error) => println!("error: {}", error),
+        Err(error) => println!("error: {error}"),
     }
 }

--- a/examples/dump-frames.rs
+++ b/examples/dump-frames.rs
@@ -59,7 +59,7 @@ fn main() -> Result<(), ffmpeg::Error> {
 }
 
 fn save_file(frame: &Video, index: usize) -> std::result::Result<(), std::io::Error> {
-    let mut file = File::create(format!("frame{}.ppm", index))?;
+    let mut file = File::create(format!("frame{index}.ppm"))?;
     file.write_all(format!("P6\n{} {}\n255\n", frame.width(), frame.height()).as_bytes())?;
     file.write_all(frame.data(0))?;
     Ok(())

--- a/examples/metadata.rs
+++ b/examples/metadata.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), ffmpeg::Error> {
     match ffmpeg::format::input(&env::args().nth(1).expect("missing file")) {
         Ok(context) => {
             for (k, v) in context.metadata().iter() {
-                println!("{}: {}", k, v);
+                println!("{k}: {v}");
             }
 
             if let Some(stream) = context.streams().best(ffmpeg::media::Type::Video) {
@@ -83,7 +83,7 @@ fn main() -> Result<(), ffmpeg::Error> {
             }
         }
 
-        Err(error) => println!("error: {}", error),
+        Err(error) => println!("error: {error}"),
     }
     Ok(())
 }

--- a/examples/transcode-x264.rs
+++ b/examples/transcode-x264.rs
@@ -173,7 +173,7 @@ fn main() {
     )
     .expect("invalid x264 options string");
 
-    eprintln!("x264 options: {:?}", x264_opts);
+    eprintln!("x264 options: {x264_opts:?}");
 
     ffmpeg::init().unwrap();
     log::set_level(log::Level::Info);

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -410,13 +410,11 @@ fn add_pkg_config_path() {
         .then_some("/opt/homebrew/lib/pkgconfig/")
         .unwrap_or("/usr/local/homebrew/lib/pkgconfig/"); // x86 as fallback
     if !pc_path.to_lowercase().contains(brew_pkgconfig) && Path::new(brew_pkgconfig).is_dir() {
-        env::var("PKG_CONFIG_PATH")
-            .map(|pc_path| {
-                env::set_var("PKG_CONFIG_PATH", format!("{brew_pkgconfig}:{pc_path}"));
-            })
-            .unwrap_or_else(|_| {
-                env::set_var("PKG_CONFIG_PATH", brew_pkgconfig);
-            });
+        let new_pc_path = env::var("PKG_CONFIG_PATH")
+            // PKG_CONFIG_PATH="/our/path:$PKG_CONFIG_PATH"
+            .map(|p| format!("{brew_pkgconfig}:{p}"))
+            .unwrap_or_else(|_| brew_pkgconfig.to_string());
+        env::set_var("PKG_CONFIG_PATH", new_pc_path);
     }
 }
 #[cfg(not(target_os = "macos"))]

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -763,10 +763,6 @@ fn main() {
     };
 
     if statik && cfg!(target_os = "macos") {
-        let brew_pkgconfig = cfg!(target_arch = "aarch64")
-            .then_some("/opt/homebrew/lib/pkgconfig/")
-            .unwrap_or("/usr/local/homebrew/lib/pkgconfig/");
-        env::set_var("PKG_CONFIG_PATH", brew_pkgconfig);
         let frameworks = vec![
             "AppKit",
             "AudioToolbox",
@@ -790,7 +786,6 @@ fn main() {
         }
     }
 
-    println!("cargo:warning={include_paths:?}");
     check_features(
         include_paths.clone(),
         &[


### PR DESCRIPTION
pkg-config does not look for M1 homebrew paths by default:

```
$ pkg-config --variable pc_path pkg-config
/usr/local/Homebrew/lib/pkgconfig:/usr/local/Homebrew/share/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:/usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig/12
```



Causing the error below:
```
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS="1" PKG_CONFIG_ALLOW_SYSTEM_LIBS="1" "pkg-config" "--libs" "--cflags" "libavutil"` did not exit successfully: exit status: 1
  error: could not find system library 'libavutil' required by the 'ffmpeg-sys-the-third' crate

  --- stderr
  Package libavutil was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libavutil.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'libavutil' found
  ', ffmpeg-sys-the-third/build.rs:738:14
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  ```
  
* Added macos/aarch64 logic for appending to pkg-search path
* Ran `cargo clippy  --fix` (happy to do it in separate PR 🤷)