### PR TITLE
Propagate errors in Input::packets().

### DIFF
--- a/examples/dump-frames.rs
+++ b/examples/dump-frames.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), ffmpeg::Error> {
                 Ok(())
             };
 
-        for (stream, packet) in ictx.packets() {
+        for (stream, packet) in ictx.packets().filter_map(Result::ok) {
             if stream.index() == video_stream_index {
                 decoder.send_packet(&packet)?;
                 receive_and_process_decoded_frames(&mut decoder)?;

--- a/examples/remux.rs
+++ b/examples/remux.rs
@@ -42,7 +42,7 @@ fn main() {
     octx.set_metadata(ictx.metadata().to_owned());
     octx.write_header().unwrap();
 
-    for (stream, mut packet) in ictx.packets() {
+    for (stream, mut packet) in ictx.packets().filter_map(Result::ok) {
         let ist_index = stream.index();
         let ost_index = stream_mapping[ist_index];
         if ost_index < 0 {

--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -225,7 +225,7 @@ fn main() {
     octx.set_metadata(ictx.metadata().to_owned());
     octx.write_header().unwrap();
 
-    for (stream, mut packet) in ictx.packets() {
+    for (stream, mut packet) in ictx.packets().filter_map(Result::ok) {
         if stream.index() == transcoder.stream {
             packet.rescale_ts(stream.time_base(), transcoder.in_time_base);
             transcoder.send_packet_to_decoder(&packet);

--- a/examples/transcode-x264.rs
+++ b/examples/transcode-x264.rs
@@ -238,7 +238,7 @@ fn main() {
         ost_time_bases[ost_index] = octx.stream(ost_index as _).unwrap().time_base();
     }
 
-    for (stream, mut packet) in ictx.packets() {
+    for (stream, mut packet) in ictx.packets().filter_map(Result::ok) {
         let ist_index = stream.index();
         let ost_index = stream_mapping[ist_index];
         if ost_index < 0 {

--- a/src/format/context/input.rs
+++ b/src/format/context/input.rs
@@ -159,24 +159,22 @@ impl<'a> PacketIter<'a> {
 }
 
 impl<'a> Iterator for PacketIter<'a> {
-    type Item = (Stream<'a>, Packet);
+    type Item = Result<(Stream<'a>, Packet), Error>;
 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         let mut packet = Packet::empty();
 
-        loop {
-            match packet.read(self.context) {
-                Ok(..) => unsafe {
-                    return Some((
-                        Stream::wrap(mem::transmute_copy(&self.context), packet.stream()),
-                        packet,
-                    ));
-                },
+        match packet.read(self.context) {
+            Ok(..) => unsafe {
+                Some(Ok((
+                    Stream::wrap(mem::transmute_copy(&self.context), packet.stream()),
+                    packet,
+                )))
+            },
 
-                Err(Error::Eof) => return None,
+            Err(Error::Eof) => None,
 
-                Err(..) => (),
-            }
+            Err(e) => Some(Err(e)),
         }
     }
 }


### PR DESCRIPTION
The current behavior of the packet iterator is to silently skip errors. This makes it unusable with interrupt callbacks because the loop never terminates.

One solution is to break on `Error::Eof | Error::Exit`.
I think a cleaner solution is to make the iterator return a `Result`, like e.g. tokio streams do it. This patch does that.

The downside is that this is a semver-major change, although the fix in the clients is trivial if they want to keep ignoring errors (see the patch to examples). Another option would be to introduce `.packets2()` function that returns this iterator.

What I don't know is if ffmpeg can throw `EINTR` or any other restartable error here which we should always ignore. From glancing over the ffmpeg code it seems that protocols already retry `EINTR`. This is only a concern [on Linux](https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html) where even `SA_RESTART` doesn't always help. BSD, Macs and [newish Windows](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsacancelblockingcall) don't have this issue as far as I know. Existing clients who filter errors won't care anyhow.