### PR TITLE
Update and fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,13 @@ env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"
 
+  # All default features except non-exhaustive-enums,
+  # to check that FFmpeg versions are properly compatible
+  CARGO_FEATURES: "
+    --no-default-features
+    -F codec,device,filter,format
+    -F software-resampling,software-scaling"
+
 jobs:
   build-test-lint-linux:
     name: Linux - FFmpeg ${{ matrix.ffmpeg_version }} - build, test and lint
@@ -32,15 +39,18 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Only save cache for one FFmpeg version
+          save-if: matrix.ffmpeg_version == "6.1"
 
       - name: Check format
         run: cargo fmt -- --check
       - name: Lint
-        run: cargo clippy --all-targets
+        run: cargo clippy --all-targets $CARGO_FEATURES
       - name: Build
-        run: cargo build --all-targets
+        run: cargo build --all-targets $CARGO_FEATURES
       - name: Test
-        run: cargo test
+        run: cargo test $CARGO_FEATURES
 
   build-test-lint-macos:
     name: macOS - FFmpeg latest - build, test and lint
@@ -49,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: brew install ffmpeg pkg-config
-      - name: Install Rust e with clippy and rustfmt
+      - name: Install Rust stable with clippy and rustfmt
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -58,11 +68,11 @@ jobs:
       - name: Check format
         run: cargo fmt -- --check
       - name: Lint
-        run: cargo clippy --all-targets
+        run: cargo clippy --all-targets $CARGO_FEATURES
       - name: Build
-        run: cargo build --all-targets
+        run: cargo build --all-targets $CARGO_FEATURES
       - name: Test
-        run: cargo test
+        run: cargo test $CARGO_FEATURES
 
   # IDK what's up with the windows CI, it's broken somehow
   # build-test-lint-windows:


### PR DESCRIPTION
This does not fix the Windows CI. I'll take a look at that later.

The current CI jobs do a really bad job of actually testing the code. `cargo test --examples` is basically a no-op. And with the new default feature `non-exhaustive-enums`, it's also not really indicative of covering the entire FFmpeg API (see the runs for 6.1, I actually missed some stuff in my PR due to this).

Merging this will result in CI failures, but I think these should be merged before the fixes so the fixes are verified properly.