### PR TITLE
Add missing enum variants for FFmpeg 6.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # Only save cache for one FFmpeg version
-          save-if: matrix.ffmpeg_version == "6.1"
+          save-if: ${{ matrix.ffmpeg_version == '6.1' }}
 
       - name: Check format
         run: cargo fmt -- --check

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -1310,6 +1310,17 @@ impl From<AVCodecID> for Id {
             #[cfg(feature = "ffmpeg_6_0")]
             AV_CODEC_ID_ANULL => Id::ANULL,
 
+            #[cfg(feature = "ffmpeg_6_1")]
+            AV_CODEC_ID_PDV => Id::PDV,
+            #[cfg(feature = "ffmpeg_6_1")]
+            AV_CODEC_ID_EVC => Id::EVC,
+            #[cfg(feature = "ffmpeg_6_1")]
+            AV_CODEC_ID_RTV1 => Id::RTV1,
+            #[cfg(feature = "ffmpeg_6_1")]
+            AV_CODEC_ID_VMIX => Id::VMIX,
+            #[cfg(feature = "ffmpeg_6_1")]
+            AV_CODEC_ID_AC4 => Id::AC4,
+
             #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -658,6 +658,10 @@ pub enum Id {
     VMIX,
     #[cfg(feature = "ffmpeg_6_1")]
     AC4,
+    #[cfg(feature = "ffmpeg_6_1")]
+    OSQ,
+    #[cfg(feature = "ffmpeg_6_1")]
+    SMPTE_2038,
 }
 
 impl Id {
@@ -1320,6 +1324,10 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_VMIX => Id::VMIX,
             #[cfg(feature = "ffmpeg_6_1")]
             AV_CODEC_ID_AC4 => Id::AC4,
+            #[cfg(feature = "ffmpeg_6_1")]
+            AV_CODEC_ID_OSQ => Id::OSQ,
+            #[cfg(feature = "ffmpeg_6_1")]
+            AV_CODEC_ID_SMPTE_2038 => Id::SMPTE_2038,
 
             #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
@@ -1976,6 +1984,10 @@ impl From<Id> for AVCodecID {
             Id::VMIX => AV_CODEC_ID_VMIX,
             #[cfg(feature = "ffmpeg_6_1")]
             Id::AC4 => AV_CODEC_ID_AC4,
+            #[cfg(feature = "ffmpeg_6_1")]
+            Id::OSQ => AV_CODEC_ID_OSQ,
+            #[cfg(feature = "ffmpeg_6_1")]
+            Id::SMPTE_2038 => AV_CODEC_ID_SMPTE_2038,
         }
     }
 }

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -414,6 +414,8 @@ pub enum Pixel {
     P412LE,
     #[cfg(feature = "ffmpeg_6_1")]
     GBRAP14BE,
+    #[cfg(feature = "ffmpeg_6_1")]
+    GBRAP14LE,
 
     #[cfg(feature = "rpi")]
     RPI,
@@ -809,6 +811,19 @@ impl From<AVPixelFormat> for Pixel {
             AV_PIX_FMT_RGBAF32BE => Pixel::RGBAF32BE,
             #[cfg(feature = "ffmpeg_6_0")]
             AV_PIX_FMT_RGBAF32LE => Pixel::RGBAF32LE,
+
+            #[cfg(feature = "ffmpeg_6_1")]
+            AV_PIX_FMT_P212BE => Pixel::P212BE,
+            #[cfg(feature = "ffmpeg_6_1")]
+            AV_PIX_FMT_P212LE => Pixel::P212LE,
+            #[cfg(feature = "ffmpeg_6_1")]
+            AV_PIX_FMT_P412BE => Pixel::P412BE,
+            #[cfg(feature = "ffmpeg_6_1")]
+            AV_PIX_FMT_P412LE => Pixel::P412LE,
+            #[cfg(feature = "ffmpeg_6_1")]
+            AV_PIX_FMT_GBRAP14BE => Pixel::GBRAP14BE,
+            #[cfg(feature = "ffmpeg_6_1")]
+            AV_PIX_FMT_GBRAP14LE => Pixel::GBRAP14LE,
 
             #[cfg(feature = "rpi")]
             AV_PIX_FMT_RPI => Pixel::RPI,
@@ -1236,6 +1251,8 @@ impl From<Pixel> for AVPixelFormat {
             Pixel::P412LE => AV_PIX_FMT_P412LE,
             #[cfg(feature = "ffmpeg_6_1")]
             Pixel::GBRAP14BE => AV_PIX_FMT_GBRAP14BE,
+            #[cfg(feature = "ffmpeg_6_1")]
+            Pixel::GBRAP14LE => AV_PIX_FMT_GBRAP14LE,
 
             #[cfg(feature = "rpi")]
             Pixel::RPI => AV_PIX_FMT_RPI,


### PR DESCRIPTION
I noticed that there are some new variants in 6.1.1, but this should fix 6.1.0 compilation.

Preferably merged after #15 so this is verified, it's a bit difficult to test with different FFmpeg versions locally.