### PR TITLE
Fix PadIter in FFmpeg pre-5.0

### DIFF
--- a/src/filter/filter.rs
+++ b/src/filter/filter.rs
@@ -48,19 +48,11 @@ impl Filter {
                 None
             } else {
                 #[cfg(feature = "ffmpeg_5_0")]
-                {
-                    Some(PadIter::new(
-                        (*self.as_ptr()).inputs,
-                        (*self.as_ptr()).nb_inputs as isize,
-                    ))
-                }
+                let count = (*self.as_ptr()).nb_inputs as isize;
                 #[cfg(not(feature = "ffmpeg_5_0"))]
-                {
-                    Some(PadIter::new(
-                        (*self.as_ptr()).inputs,
-                        (*self.as_ptr()).inputs as isize,
-                    ))
-                }
+                let count = avfilter_pad_count(ptr) as isize;
+
+                Some(PadIter::new(ptr, count))
             }
         }
     }
@@ -73,19 +65,11 @@ impl Filter {
                 None
             } else {
                 #[cfg(feature = "ffmpeg_5_0")]
-                {
-                    Some(PadIter::new(
-                        (*self.as_ptr()).outputs,
-                        (*self.as_ptr()).nb_outputs as isize,
-                    ))
-                }
+                let count = (*self.as_ptr()).nb_outputs as isize;
                 #[cfg(not(feature = "ffmpeg_5_0"))]
-                {
-                    Some(PadIter::new(
-                        (*self.as_ptr()).outputs,
-                        (*self.as_ptr()).outputs as isize,
-                    ))
-                }
+                let count = avfilter_pad_count(ptr) as isize;
+
+                Some(PadIter::new(ptr, count))
             }
         }
     }


### PR DESCRIPTION
`avfilter_pad_count` still exists in 5.0 and beyond (renamed to `avfilter_filter_pad_count`), but it is unnecessary because `nb_outputs`/`nb_inputs` exists. The old code makes no sense at all (passing a pointer as `count` parameter).

CI should show that all tests < 5.0 pass.