### PR TITLE
Migrate crates to Rust edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ffmpeg-the-third"
 version = "1.3.0+ffmpeg-6.1"
 build = "build.rs"
+edition = "2021"
 
 authors = ["meh. <meh@schizofreni.co>", "Zhiming Wang <i@zhimingwang.org>"]
 license = "WTFPL"

--- a/examples/dump-frames.rs
+++ b/examples/dump-frames.rs
@@ -1,9 +1,9 @@
 extern crate ffmpeg_the_third as ffmpeg;
 
-use ffmpeg::format::{input, Pixel};
-use ffmpeg::media::Type;
-use ffmpeg::software::scaling::{context::Context, flag::Flags};
-use ffmpeg::util::frame::video::Video;
+use crate::ffmpeg::format::{input, Pixel};
+use crate::ffmpeg::media::Type;
+use crate::ffmpeg::software::scaling::{context::Context, flag::Flags};
+use crate::ffmpeg::util::frame::video::Video;
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;

--- a/examples/remux.rs
+++ b/examples/remux.rs
@@ -2,7 +2,7 @@ extern crate ffmpeg_the_third as ffmpeg;
 
 use std::env;
 
-use ffmpeg::{codec, encoder, format, log, media, Rational};
+use crate::ffmpeg::{codec, encoder, format, log, media, Rational};
 
 fn main() {
     let input_file = env::args().nth(1).expect("missing input file");

--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -3,8 +3,8 @@ extern crate ffmpeg_the_third as ffmpeg;
 use std::env;
 use std::path::Path;
 
-use ffmpeg::{codec, filter, format, frame, media};
-use ffmpeg::{rescale, Rescale};
+use crate::ffmpeg::{codec, filter, format, frame, media};
+use crate::ffmpeg::{rescale, Rescale};
 
 fn filter(
     spec: &str,

--- a/examples/transcode-x264.rs
+++ b/examples/transcode-x264.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::env;
 use std::time::Instant;
 
-use ffmpeg::{
+use crate::ffmpeg::{
     codec, decoder, encoder, format, frame, log, media, picture, Dictionary, Packet, Rational,
 };
 

--- a/ffmpeg-sys-the-third/Cargo.toml
+++ b/ffmpeg-sys-the-third/Cargo.toml
@@ -3,6 +3,7 @@ name = "ffmpeg-sys-the-third"
 version = "1.2.0+ffmpeg-6.1"
 build = "build.rs"
 links = "ffmpeg"
+edition = "2021"
 
 authors = [
     "meh. <meh@schizofreni.co>",

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -115,7 +115,7 @@ impl ParseCallbacks for Callbacks {
 
     // https://github.com/rust-lang/rust-bindgen/issues/687#issuecomment-388277405
     fn will_parse_macro(&self, name: &str) -> MacroParsingBehavior {
-        use MacroParsingBehavior::*;
+        use crate::MacroParsingBehavior::*;
 
         match name {
             "FP_INFINITE" => Ignore,

--- a/ffmpeg-sys-the-third/src/avutil/pixfmt.rs
+++ b/ffmpeg-sys-the-third/src/avutil/pixfmt.rs
@@ -1,5 +1,5 @@
-use AVPixelFormat;
-use AVPixelFormat::*;
+use crate::AVPixelFormat;
+use crate::AVPixelFormat::*;
 
 #[cfg(target_endian = "little")]
 pub const AV_PIX_FMT_RGB32: AVPixelFormat = AV_PIX_FMT_BGRA;

--- a/ffmpeg-sys-the-third/src/avutil/rational.rs
+++ b/ffmpeg-sys-the-third/src/avutil/rational.rs
@@ -1,5 +1,5 @@
 use libc::{c_double, c_int};
-use AVRational;
+use crate::AVRational;
 
 #[inline(always)]
 pub unsafe fn av_make_q(num: c_int, den: c_int) -> AVRational {

--- a/ffmpeg-sys-the-third/src/avutil/util.rs
+++ b/ffmpeg-sys-the-third/src/avutil/util.rs
@@ -1,5 +1,5 @@
 use libc::c_int;
-use {AVRational, AV_TIME_BASE};
+use crate::{AVRational, AV_TIME_BASE};
 
 pub const AV_NOPTS_VALUE: i64 = 0x8000000000000000u64 as i64;
 pub const AV_TIME_BASE_Q: AVRational = AVRational {

--- a/ffmpeg-sys-the-third/src/lib.rs
+++ b/ffmpeg-sys-the-third/src/lib.rs
@@ -13,4 +13,4 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[macro_use]
 mod avutil;
-pub use avutil::*;
+pub use crate::avutil::*;

--- a/src/codec/audio.rs
+++ b/src/codec/audio.rs
@@ -1,8 +1,8 @@
 use std::ops::Deref;
 
 use super::codec::Codec;
-use ffi::*;
-use {format, ChannelLayout};
+use crate::ffi::*;
+use crate::{format, ChannelLayout};
 
 #[derive(PartialEq, Eq, Copy, Clone)]
 pub struct Audio {

--- a/src/codec/audio_service.rs
+++ b/src/codec/audio_service.rs
@@ -1,5 +1,5 @@
-use ffi::AVAudioServiceType::*;
-use ffi::*;
+use crate::ffi::AVAudioServiceType::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/codec/capabilities.rs
+++ b/src/codec/capabilities.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_uint;
 
 bitflags! {

--- a/src/codec/codec.rs
+++ b/src/codec/codec.rs
@@ -2,8 +2,8 @@ use std::ffi::CStr;
 use std::str::from_utf8_unchecked;
 
 use super::{Audio, Capabilities, Id, Profile, Video};
-use ffi::*;
-use {media, Error};
+use crate::ffi::*;
+use crate::{media, Error};
 
 #[derive(PartialEq, Eq, Copy, Clone)]
 pub struct Codec {

--- a/src/codec/compliance.rs
+++ b/src/codec/compliance.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};

--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -5,10 +5,10 @@ use std::rc::Rc;
 use super::decoder::Decoder;
 use super::encoder::Encoder;
 use super::{threading, Compliance, Debug, Flags, Id, Parameters};
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
-use media;
-use {Codec, Error};
+use crate::media;
+use crate::{Codec, Error};
 
 pub struct Context {
     ptr: *mut AVCodecContext,

--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -6,9 +6,9 @@ use super::decoder::Decoder;
 use super::encoder::Encoder;
 use super::{threading, Compliance, Debug, Flags, Id, Parameters};
 use crate::ffi::*;
-use libc::c_int;
 use crate::media;
 use crate::{Codec, Error};
+use libc::c_int;
 
 pub struct Context {
     ptr: *mut AVCodecContext,

--- a/src/codec/debug.rs
+++ b/src/codec/debug.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 bitflags! {

--- a/src/codec/decoder/audio.rs
+++ b/src/codec/decoder/audio.rs
@@ -1,18 +1,18 @@
 use std::ops::{Deref, DerefMut};
 
 #[cfg(not(feature = "ffmpeg_5_0"))]
-use ffi::*;
+use crate::ffi::*;
 #[cfg(not(feature = "ffmpeg_5_0"))]
 use libc::c_int;
 
 use super::Opened;
-use codec::Context;
+use crate::codec::Context;
 #[cfg(not(feature = "ffmpeg_5_0"))]
-use frame;
-use util::format;
+use crate::frame;
+use crate::util::format;
 #[cfg(not(feature = "ffmpeg_5_0"))]
-use {packet, Error};
-use {AudioService, ChannelLayout};
+use crate::{packet, Error};
+use crate::{AudioService, ChannelLayout};
 
 pub struct Audio(pub Opened);
 

--- a/src/codec/decoder/check.rs
+++ b/src/codec/decoder/check.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 bitflags! {

--- a/src/codec/decoder/conceal.rs
+++ b/src/codec/decoder/conceal.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 bitflags! {

--- a/src/codec/decoder/decoder.rs
+++ b/src/codec/decoder/decoder.rs
@@ -2,9 +2,9 @@ use std::ops::{Deref, DerefMut};
 use std::ptr;
 
 use super::{Audio, Check, Conceal, Opened, Subtitle, Video};
-use codec::{traits, Context};
-use ffi::*;
-use {Dictionary, Discard, Error, Rational};
+use crate::codec::{traits, Context};
+use crate::ffi::*;
+use crate::{Dictionary, Discard, Error, Rational};
 
 pub struct Decoder(pub Context);
 

--- a/src/codec/decoder/mod.rs
+++ b/src/codec/decoder/mod.rs
@@ -23,10 +23,10 @@ pub use self::opened::Opened;
 
 use std::ffi::CString;
 
-use codec::Context;
-use codec::Id;
-use ffi::*;
-use Codec;
+use crate::codec::Context;
+use crate::codec::Id;
+use crate::ffi::*;
+use crate::Codec;
 
 pub fn new() -> Decoder {
     Context::new().decoder()

--- a/src/codec/decoder/opened.rs
+++ b/src/codec/decoder/opened.rs
@@ -2,9 +2,9 @@ use std::ops::{Deref, DerefMut};
 use std::ptr;
 
 use super::{Audio, Decoder, Subtitle, Video};
-use codec::{Context, Profile};
-use ffi::*;
-use {media, packet, Error, Frame, Rational};
+use crate::codec::{Context, Profile};
+use crate::ffi::*;
+use crate::{media, packet, Error, Frame, Rational};
 
 pub struct Opened(pub Decoder);
 

--- a/src/codec/decoder/slice.rs
+++ b/src/codec/decoder/slice.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 bitflags! {

--- a/src/codec/decoder/subtitle.rs
+++ b/src/codec/decoder/subtitle.rs
@@ -1,11 +1,11 @@
 use std::ops::{Deref, DerefMut};
 
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 use super::Opened;
-use codec::Context;
-use {packet, Error};
+use crate::codec::Context;
+use crate::{packet, Error};
 
 pub struct Subtitle(pub Opened);
 
@@ -13,7 +13,7 @@ impl Subtitle {
     pub fn decode<P: packet::Ref>(
         &mut self,
         packet: &P,
-        out: &mut ::Subtitle,
+        out: &mut crate::Subtitle,
     ) -> Result<bool, Error> {
         unsafe {
             let mut got: c_int = 0;

--- a/src/codec/decoder/video.rs
+++ b/src/codec/decoder/video.rs
@@ -1,19 +1,19 @@
 use std::ops::{Deref, DerefMut};
 
 #[cfg(not(feature = "ffmpeg_5_0"))]
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 use super::{slice, Opened};
-use codec::Context;
-use color;
+use crate::codec::Context;
+use crate::color;
 #[cfg(not(feature = "ffmpeg_5_0"))]
-use frame;
-use util::chroma;
-use util::format;
+use crate::frame;
+use crate::util::chroma;
+use crate::util::format;
 #[cfg(not(feature = "ffmpeg_5_0"))]
-use {packet, Error};
-use {FieldOrder, Rational};
+use crate::{packet, Error};
+use crate::{FieldOrder, Rational};
 
 pub struct Video(pub Opened);
 

--- a/src/codec/discard.rs
+++ b/src/codec/discard.rs
@@ -1,5 +1,5 @@
-use ffi::AVDiscard::*;
-use ffi::*;
+use crate::ffi::AVDiscard::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/codec/encoder/audio.rs
+++ b/src/codec/encoder/audio.rs
@@ -1,16 +1,16 @@
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 
-use ffi::*;
+use crate::ffi::*;
 #[cfg(not(feature = "ffmpeg_5_0"))]
 use libc::c_int;
 
 use super::Encoder as Super;
-use codec::{traits, Context};
-use util::format;
+use crate::codec::{traits, Context};
+use crate::util::format;
 #[cfg(not(feature = "ffmpeg_5_0"))]
-use {frame, packet};
-use {ChannelLayout, Dictionary, Error};
+use crate::{frame, packet};
+use crate::{ChannelLayout, Dictionary, Error};
 
 pub struct Audio(pub Super);
 

--- a/src/codec/encoder/comparison.rs
+++ b/src/codec/encoder/comparison.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};

--- a/src/codec/encoder/decision.rs
+++ b/src/codec/encoder/decision.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};

--- a/src/codec/encoder/encoder.rs
+++ b/src/codec/encoder/encoder.rs
@@ -1,12 +1,12 @@
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 use super::{audio, subtitle, video};
-use codec::Context;
-use {media, packet, Error, Frame, Rational};
+use crate::codec::Context;
+use crate::{media, packet, Error, Frame, Rational};
 
 pub struct Encoder(pub Context);
 

--- a/src/codec/encoder/mod.rs
+++ b/src/codec/encoder/mod.rs
@@ -26,10 +26,10 @@ pub use self::decision::Decision;
 
 use std::ffi::CString;
 
-use codec::Context;
-use codec::Id;
-use ffi::*;
-use Codec;
+use crate::codec::Context;
+use crate::codec::Id;
+use crate::ffi::*;
+use crate::Codec;
 
 pub fn new() -> Encoder {
     Context::new().encoder()

--- a/src/codec/encoder/prediction.rs
+++ b/src/codec/encoder/prediction.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};

--- a/src/codec/encoder/subtitle.rs
+++ b/src/codec/encoder/subtitle.rs
@@ -1,12 +1,12 @@
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 use super::Encoder as Super;
-use codec::{traits, Context};
-use {Dictionary, Error};
+use crate::codec::{traits, Context};
+use crate::{Dictionary, Error};
 
 pub struct Subtitle(pub Super);
 
@@ -85,7 +85,7 @@ impl AsMut<Context> for Subtitle {
 pub struct Encoder(pub Subtitle);
 
 impl Encoder {
-    pub fn encode(&mut self, subtitle: &::Subtitle, out: &mut [u8]) -> Result<bool, Error> {
+    pub fn encode(&mut self, subtitle: &crate::Subtitle, out: &mut [u8]) -> Result<bool, Error> {
         unsafe {
             match avcodec_encode_subtitle(
                 self.0.as_mut_ptr(),

--- a/src/codec/encoder/video.rs
+++ b/src/codec/encoder/video.rs
@@ -1,17 +1,17 @@
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 
-use ffi::*;
+use crate::ffi::*;
 use libc::{c_float, c_int};
 
 use super::Encoder as Super;
 use super::{Comparison, Decision};
 #[cfg(not(feature = "ffmpeg_5_0"))]
 use super::{MotionEstimation, Prediction};
-use codec::{traits, Context};
-use {color, format, Dictionary, Error, Rational};
+use crate::codec::{traits, Context};
+use crate::{color, format, Dictionary, Error, Rational};
 #[cfg(not(feature = "ffmpeg_5_0"))]
-use {frame, packet};
+use crate::{frame, packet};
 
 pub struct Video(pub Super);
 

--- a/src/codec/field_order.rs
+++ b/src/codec/field_order.rs
@@ -1,5 +1,5 @@
-use ffi::AVFieldOrder::*;
-use ffi::*;
+use crate::ffi::AVFieldOrder::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/codec/flag.rs
+++ b/src/codec/flag.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_uint;
 
 bitflags! {

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -3,9 +3,9 @@ use std::str::from_utf8_unchecked;
 
 use crate::ffi::AVCodecID::*;
 use crate::ffi::*;
+use crate::util::media;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
-use crate::util::media;
 
 #[allow(non_camel_case_types)]
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -1,11 +1,11 @@
 use std::ffi::CStr;
 use std::str::from_utf8_unchecked;
 
-use ffi::AVCodecID::*;
-use ffi::*;
+use crate::ffi::AVCodecID::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
-use util::media;
+use crate::util::media;
 
 #[allow(non_camel_case_types)]
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -51,7 +51,7 @@ pub mod traits;
 use std::ffi::CStr;
 use std::str::from_utf8_unchecked;
 
-use ffi::*;
+use crate::ffi::*;
 
 pub fn version() -> u32 {
     unsafe { avcodec_version() }

--- a/src/codec/packet/borrow.rs
+++ b/src/codec/packet/borrow.rs
@@ -2,7 +2,7 @@ use std::mem;
 use std::ptr;
 
 use super::Ref;
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 pub struct Borrow<'a> {

--- a/src/codec/packet/flag.rs
+++ b/src/codec/packet/flag.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 bitflags! {

--- a/src/codec/packet/packet.rs
+++ b/src/codec/packet/packet.rs
@@ -3,9 +3,9 @@ use std::mem;
 use std::slice;
 
 use super::{Borrow, Flags, Mut, Ref, SideData};
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
-use {format, Error, Rational};
+use crate::{format, Error, Rational};
 
 pub struct Packet(AVPacket);
 

--- a/src/codec/packet/packet.rs
+++ b/src/codec/packet/packet.rs
@@ -4,8 +4,8 @@ use std::slice;
 
 use super::{Borrow, Flags, Mut, Ref, SideData};
 use crate::ffi::*;
-use libc::c_int;
 use crate::{format, Error, Rational};
+use libc::c_int;
 
 pub struct Packet(AVPacket);
 

--- a/src/codec/packet/side_data.rs
+++ b/src/codec/packet/side_data.rs
@@ -2,8 +2,8 @@ use std::marker::PhantomData;
 use std::slice;
 
 use super::Packet;
-use ffi::AVPacketSideDataType::*;
-use ffi::*;
+use crate::ffi::AVPacketSideDataType::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/codec/packet/traits.rs
+++ b/src/codec/packet/traits.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 
 pub trait Ref {
     fn as_ptr(&self) -> *const AVPacket;

--- a/src/codec/parameters.rs
+++ b/src/codec/parameters.rs
@@ -2,8 +2,8 @@ use std::any::Any;
 use std::rc::Rc;
 
 use super::{Context, Id};
-use ffi::*;
-use media;
+use crate::ffi::*;
+use crate::media;
 
 pub struct Parameters {
     ptr: *mut AVCodecParameters,

--- a/src/codec/picture.rs
+++ b/src/codec/picture.rs
@@ -2,10 +2,10 @@ use std::marker::PhantomData;
 use std::mem;
 use std::slice;
 
-use ffi::*;
-use format;
+use crate::ffi::*;
+use crate::format;
 use libc::{c_int, size_t};
-use Error;
+use crate::Error;
 
 pub struct Picture<'a> {
     ptr: *mut AVPicture,

--- a/src/codec/picture.rs
+++ b/src/codec/picture.rs
@@ -4,8 +4,8 @@ use std::slice;
 
 use crate::ffi::*;
 use crate::format;
-use libc::{c_int, size_t};
 use crate::Error;
+use libc::{c_int, size_t};
 
 pub struct Picture<'a> {
     ptr: *mut AVPicture,

--- a/src/codec/profile.rs
+++ b/src/codec/profile.rs
@@ -1,5 +1,5 @@
 use super::Id;
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};

--- a/src/codec/subtitle/flag.rs
+++ b/src/codec/subtitle/flag.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 bitflags! {

--- a/src/codec/subtitle/mod.rs
+++ b/src/codec/subtitle/mod.rs
@@ -10,8 +10,8 @@ pub use self::rect_mut::{AssMut, BitmapMut, RectMut, TextMut};
 use std::marker::PhantomData;
 use std::mem;
 
-use ffi::AVSubtitleType::*;
-use ffi::*;
+use crate::ffi::AVSubtitleType::*;
+use crate::ffi::*;
 use libc::{c_uint, size_t};
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};

--- a/src/codec/subtitle/rect.rs
+++ b/src/codec/subtitle/rect.rs
@@ -3,9 +3,9 @@ use std::marker::PhantomData;
 use std::str::from_utf8_unchecked;
 
 use super::{Flags, Type};
-use ffi::*;
+use crate::ffi::*;
 #[cfg(not(feature = "ffmpeg_5_0"))]
-use {format, Picture};
+use crate::{format, Picture};
 
 pub enum Rect<'a> {
     None(*const AVSubtitleRect),

--- a/src/codec/subtitle/rect_mut.rs
+++ b/src/codec/subtitle/rect_mut.rs
@@ -2,7 +2,7 @@ use std::ffi::CString;
 use std::ops::Deref;
 
 use super::{Ass, Bitmap, Flags, Text, Type};
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 pub enum RectMut<'a> {

--- a/src/codec/threading.rs
+++ b/src/codec/threading.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};

--- a/src/codec/traits.rs
+++ b/src/codec/traits.rs
@@ -1,6 +1,6 @@
 use super::{decoder, encoder};
-use codec::{Audio, Id, Video};
-use Codec;
+use crate::codec::{Audio, Id, Video};
+use crate::Codec;
 
 pub trait Decoder {
     fn decoder(self) -> Option<Codec>;

--- a/src/codec/video.rs
+++ b/src/codec/video.rs
@@ -1,8 +1,8 @@
 use std::ops::Deref;
 
 use super::codec::Codec;
-use ffi::*;
-use {format, Rational};
+use crate::ffi::*;
+use crate::{format, Rational};
 
 #[derive(PartialEq, Eq, Copy, Clone)]
 pub struct Video {

--- a/src/device/extensions.rs
+++ b/src/device/extensions.rs
@@ -1,11 +1,11 @@
 use std::marker::PhantomData;
 use std::ptr;
 
-use device;
-use ffi::*;
-use format::context::common::Context;
+use crate::device;
+use crate::ffi::*;
+use crate::format::context::common::Context;
 use libc::c_int;
-use Error;
+use crate::Error;
 
 impl Context {
     pub fn devices(&self) -> Result<DeviceIter, Error> {

--- a/src/device/extensions.rs
+++ b/src/device/extensions.rs
@@ -4,8 +4,8 @@ use std::ptr;
 use crate::device;
 use crate::ffi::*;
 use crate::format::context::common::Context;
-use libc::c_int;
 use crate::Error;
+use libc::c_int;
 
 impl Context {
     pub fn devices(&self) -> Result<DeviceIter, Error> {

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -1,8 +1,8 @@
 use std::ptr;
 
-use ffi::*;
-use format;
-use Format;
+use crate::ffi::*;
+use crate::format;
+use crate::Format;
 
 pub struct AudioIter(*mut AVInputFormat);
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -6,7 +6,7 @@ use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::str::from_utf8_unchecked;
 
-use ffi::*;
+use crate::ffi::*;
 
 pub struct Info<'a> {
     ptr: *mut AVDeviceInfo,

--- a/src/device/output.rs
+++ b/src/device/output.rs
@@ -1,8 +1,8 @@
 use std::ptr;
 
-use ffi::*;
-use format;
-use Format;
+use crate::ffi::*;
+use crate::format;
+use crate::Format;
 
 pub struct AudioIter(*mut AVOutputFormat);
 

--- a/src/filter/context/context.rs
+++ b/src/filter/context/context.rs
@@ -2,8 +2,8 @@ use std::marker::PhantomData;
 
 use super::{Sink, Source};
 use crate::ffi::*;
-use libc::c_void;
 use crate::{format, option, ChannelLayout};
+use libc::c_void;
 
 pub struct Context<'a> {
     ptr: *mut AVFilterContext,

--- a/src/filter/context/context.rs
+++ b/src/filter/context/context.rs
@@ -1,9 +1,9 @@
 use std::marker::PhantomData;
 
 use super::{Sink, Source};
-use ffi::*;
+use crate::ffi::*;
 use libc::c_void;
-use {format, option, ChannelLayout};
+use crate::{format, option, ChannelLayout};
 
 pub struct Context<'a> {
     ptr: *mut AVFilterContext,

--- a/src/filter/context/sink.rs
+++ b/src/filter/context/sink.rs
@@ -1,7 +1,7 @@
 use super::Context;
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
-use {Error, Frame};
+use crate::{Error, Frame};
 
 pub struct Sink<'a> {
     ctx: &'a mut Context<'a>,

--- a/src/filter/context/sink.rs
+++ b/src/filter/context/sink.rs
@@ -1,7 +1,7 @@
 use super::Context;
 use crate::ffi::*;
-use libc::c_int;
 use crate::{Error, Frame};
+use libc::c_int;
 
 pub struct Sink<'a> {
     ctx: &'a mut Context<'a>,

--- a/src/filter/context/source.rs
+++ b/src/filter/context/source.rs
@@ -1,8 +1,8 @@
 use std::ptr;
 
 use super::Context;
-use ffi::*;
-use {Error, Frame};
+use crate::ffi::*;
+use crate::{Error, Frame};
 
 pub struct Source<'a> {
     ctx: &'a mut Context<'a>,

--- a/src/filter/filter.rs
+++ b/src/filter/filter.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::str::from_utf8_unchecked;
 
 use super::{Flags, Pad};
-use ffi::*;
+use crate::ffi::*;
 
 pub struct Filter {
     ptr: *mut AVFilter,

--- a/src/filter/flag.rs
+++ b/src/filter/flag.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 bitflags! {

--- a/src/filter/graph.rs
+++ b/src/filter/graph.rs
@@ -4,8 +4,8 @@ use std::str::from_utf8_unchecked;
 
 use super::{Context, Filter};
 use crate::ffi::*;
-use libc::c_int;
 use crate::Error;
+use libc::c_int;
 
 pub struct Graph {
     ptr: *mut AVFilterGraph,

--- a/src/filter/graph.rs
+++ b/src/filter/graph.rs
@@ -3,9 +3,9 @@ use std::ptr;
 use std::str::from_utf8_unchecked;
 
 use super::{Context, Filter};
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
-use Error;
+use crate::Error;
 
 pub struct Graph {
     ptr: *mut AVFilterGraph,

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -16,9 +16,9 @@ pub use self::graph::Graph;
 use std::ffi::{CStr, CString};
 use std::str::from_utf8_unchecked;
 
-use ffi::*;
+use crate::ffi::*;
 #[cfg(not(feature = "ffmpeg_5_0"))]
-use Error;
+use crate::Error;
 
 #[cfg(not(feature = "ffmpeg_5_0"))]
 pub fn register_all() {

--- a/src/filter/pad.rs
+++ b/src/filter/pad.rs
@@ -2,8 +2,8 @@ use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::str::from_utf8_unchecked;
 
-use ffi::*;
-use media;
+use crate::ffi::*;
+use crate::media;
 
 pub struct Pad<'a> {
     ptr: *const AVFilterPad,

--- a/src/format/chapter/chapter.rs
+++ b/src/format/chapter/chapter.rs
@@ -1,7 +1,7 @@
-use ffi::*;
-use {DictionaryRef, Rational};
+use crate::ffi::*;
+use crate::{DictionaryRef, Rational};
 
-use format::context::common::Context;
+use crate::format::context::common::Context;
 
 // WARNING: index refers to the offset in the chapters array (starting from 0)
 // it is not necessarly equal to the id (which may start at 1)

--- a/src/format/chapter/chapter_mut.rs
+++ b/src/format/chapter/chapter_mut.rs
@@ -2,9 +2,9 @@ use std::mem;
 use std::ops::Deref;
 
 use super::Chapter;
-use ffi::*;
-use format::context::common::Context;
-use {Dictionary, DictionaryMut, Rational};
+use crate::ffi::*;
+use crate::format::context::common::Context;
+use crate::{Dictionary, DictionaryMut, Rational};
 
 // WARNING: index refers to the offset in the chapters array (starting from 0)
 // it is not necessarly equal to the id (which may start at 1)

--- a/src/format/context/common.rs
+++ b/src/format/context/common.rs
@@ -4,9 +4,9 @@ use std::ptr;
 use std::rc::Rc;
 
 use super::destructor::{self, Destructor};
-use ffi::*;
+use crate::ffi::*;
 use libc::{c_int, c_uint};
-use {media, Chapter, ChapterMut, DictionaryRef, Stream, StreamMut};
+use crate::{media, Chapter, ChapterMut, DictionaryRef, Stream, StreamMut};
 
 pub struct Context {
     ptr: *mut AVFormatContext,

--- a/src/format/context/common.rs
+++ b/src/format/context/common.rs
@@ -5,8 +5,8 @@ use std::rc::Rc;
 
 use super::destructor::{self, Destructor};
 use crate::ffi::*;
-use libc::{c_int, c_uint};
 use crate::{media, Chapter, ChapterMut, DictionaryRef, Stream, StreamMut};
+use libc::{c_int, c_uint};
 
 pub struct Context {
     ptr: *mut AVFormatContext,

--- a/src/format/context/destructor.rs
+++ b/src/format/context/destructor.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/format/context/input.rs
+++ b/src/format/context/input.rs
@@ -4,11 +4,11 @@ use std::ops::{Deref, DerefMut};
 
 use super::common::Context;
 use super::destructor;
-use ffi::*;
-use util::range::Range;
+use crate::ffi::*;
+use crate::util::range::Range;
 #[cfg(not(feature = "ffmpeg_5_0"))]
-use Codec;
-use {format, Error, Packet, Stream};
+use crate::Codec;
+use crate::{format, Error, Packet, Stream};
 
 pub struct Input {
     ptr: *mut AVFormatContext,

--- a/src/format/context/output.rs
+++ b/src/format/context/output.rs
@@ -5,9 +5,9 @@ use std::ptr;
 
 use super::common::Context;
 use super::destructor;
-use codec::traits;
-use ffi::*;
-use {format, ChapterMut, Dictionary, Error, Rational, StreamMut};
+use crate::codec::traits;
+use crate::ffi::*;
+use crate::{format, ChapterMut, Dictionary, Error, Rational, StreamMut};
 
 pub struct Output {
     ptr: *mut AVFormatContext,

--- a/src/format/format/flag.rs
+++ b/src/format/format/flag.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 bitflags! {

--- a/src/format/format/input.rs
+++ b/src/format/format/input.rs
@@ -1,7 +1,7 @@
 use std::ffi::CStr;
 use std::str::from_utf8_unchecked;
 
-use ffi::*;
+use crate::ffi::*;
 
 pub struct Input {
     ptr: *mut AVInputFormat,

--- a/src/format/format/iter.rs
+++ b/src/format/format/iter.rs
@@ -1,7 +1,7 @@
 use std::ptr;
 
 use super::{Format, Input, Output};
-use ffi::*;
+use crate::ffi::*;
 
 pub struct Iter {
     input: *mut AVInputFormat,

--- a/src/format/format/output.rs
+++ b/src/format/format/output.rs
@@ -5,8 +5,8 @@ use std::ptr;
 use std::str::from_utf8_unchecked;
 
 use super::Flags;
-use ffi::*;
-use {codec, media};
+use crate::ffi::*;
+use crate::{codec, media};
 
 pub struct Output {
     ptr: *mut AVOutputFormat,

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1,6 +1,6 @@
-pub use util::format::{pixel, Pixel};
-pub use util::format::{sample, Sample};
-use util::interrupt;
+pub use crate::util::format::{pixel, Pixel};
+pub use crate::util::format::{sample, Sample};
+use crate::util::interrupt;
 
 pub mod stream;
 
@@ -22,8 +22,8 @@ use std::path::Path;
 use std::ptr;
 use std::str::from_utf8_unchecked;
 
-use ffi::*;
-use {Dictionary, Error, Format};
+use crate::ffi::*;
+use crate::{Dictionary, Error, Format};
 
 #[cfg(not(feature = "ffmpeg_5_0"))]
 pub fn register_all() {

--- a/src/format/network.rs
+++ b/src/format/network.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 
 pub fn init() {
     unsafe {

--- a/src/format/stream/disposition.rs
+++ b/src/format/stream/disposition.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 bitflags! {

--- a/src/format/stream/stream.rs
+++ b/src/format/stream/stream.rs
@@ -1,9 +1,9 @@
 use super::Disposition;
-use codec::{self, packet};
-use ffi::*;
-use format::context::common::Context;
+use crate::codec::{self, packet};
+use crate::ffi::*;
+use crate::format::context::common::Context;
 use libc::c_int;
-use {DictionaryRef, Discard, Rational};
+use crate::{DictionaryRef, Discard, Rational};
 
 #[derive(Debug)]
 pub struct Stream<'a> {

--- a/src/format/stream/stream.rs
+++ b/src/format/stream/stream.rs
@@ -2,8 +2,8 @@ use super::Disposition;
 use crate::codec::{self, packet};
 use crate::ffi::*;
 use crate::format::context::common::Context;
-use libc::c_int;
 use crate::{DictionaryRef, Discard, Rational};
+use libc::c_int;
 
 #[derive(Debug)]
 pub struct Stream<'a> {

--- a/src/format/stream/stream_mut.rs
+++ b/src/format/stream/stream_mut.rs
@@ -2,9 +2,9 @@ use std::mem;
 use std::ops::Deref;
 
 use super::Stream;
-use ffi::*;
-use format::context::common::Context;
-use {codec, Dictionary, Rational};
+use crate::ffi::*;
+use crate::format::context::common::Context;
+use crate::{codec, Dictionary, Rational};
 
 pub struct StreamMut<'a> {
     context: &'a mut Context,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,56 +14,56 @@ extern crate libc;
 #[cfg(feature = "serialize")]
 extern crate serde;
 
-pub use sys as ffi;
+pub use crate::sys as ffi;
 
 #[macro_use]
 pub mod util;
-pub use util::channel_layout::{self, ChannelLayout};
-pub use util::chroma;
-pub use util::color;
-pub use util::dictionary;
-pub use util::dictionary::Mut as DictionaryMut;
-pub use util::dictionary::Owned as Dictionary;
-pub use util::dictionary::Ref as DictionaryRef;
-pub use util::error::{self, Error};
-pub use util::frame::{self, Frame};
-pub use util::log;
-pub use util::mathematics::{self, rescale, Rescale, Rounding};
-pub use util::media;
-pub use util::option;
-pub use util::picture;
-pub use util::rational::{self, Rational};
-pub use util::time;
+pub use crate::util::channel_layout::{self, ChannelLayout};
+pub use crate::util::chroma;
+pub use crate::util::color;
+pub use crate::util::dictionary;
+pub use crate::util::dictionary::Mut as DictionaryMut;
+pub use crate::util::dictionary::Owned as Dictionary;
+pub use crate::util::dictionary::Ref as DictionaryRef;
+pub use crate::util::error::{self, Error};
+pub use crate::util::frame::{self, Frame};
+pub use crate::util::log;
+pub use crate::util::mathematics::{self, rescale, Rescale, Rounding};
+pub use crate::util::media;
+pub use crate::util::option;
+pub use crate::util::picture;
+pub use crate::util::rational::{self, Rational};
+pub use crate::util::time;
 
 #[cfg(feature = "format")]
 pub mod format;
 #[cfg(feature = "format")]
-pub use format::chapter::{Chapter, ChapterMut};
+pub use crate::format::chapter::{Chapter, ChapterMut};
 #[cfg(feature = "format")]
-pub use format::format::Format;
+pub use crate::format::format::Format;
 #[cfg(feature = "format")]
-pub use format::stream::{Stream, StreamMut};
+pub use crate::format::stream::{Stream, StreamMut};
 
 #[cfg(feature = "codec")]
 pub mod codec;
 #[cfg(feature = "codec")]
-pub use codec::audio_service::AudioService;
+pub use crate::codec::audio_service::AudioService;
 #[cfg(feature = "codec")]
-pub use codec::codec::Codec;
+pub use crate::codec::codec::Codec;
 #[cfg(feature = "codec")]
-pub use codec::discard::Discard;
+pub use crate::codec::discard::Discard;
 #[cfg(feature = "codec")]
-pub use codec::field_order::FieldOrder;
+pub use crate::codec::field_order::FieldOrder;
 #[cfg(feature = "codec")]
-pub use codec::packet::{self, Packet};
+pub use crate::codec::packet::{self, Packet};
 #[cfg(all(feature = "codec", not(feature = "ffmpeg_5_0")))]
-pub use codec::picture::Picture;
+pub use crate::codec::picture::Picture;
 #[cfg(feature = "codec")]
-pub use codec::subtitle::{self, Subtitle};
+pub use crate::codec::subtitle::{self, Subtitle};
 #[cfg(feature = "codec")]
-pub use codec::threading;
+pub use crate::codec::threading;
 #[cfg(feature = "codec")]
-pub use codec::{decoder, encoder};
+pub use crate::codec::{decoder, encoder};
 
 #[cfg(feature = "device")]
 pub mod device;
@@ -71,7 +71,7 @@ pub mod device;
 #[cfg(feature = "filter")]
 pub mod filter;
 #[cfg(feature = "filter")]
-pub use filter::Filter;
+pub use crate::filter::Filter;
 
 pub mod software;
 

--- a/src/software/mod.rs
+++ b/src/software/mod.rs
@@ -4,11 +4,11 @@ pub mod scaling;
 #[cfg(feature = "software-scaling")]
 #[inline]
 pub fn scaler(
-    format: ::format::Pixel,
+    format: crate::format::Pixel,
     flags: scaling::Flags,
     (in_width, in_height): (u32, u32),
     (out_width, out_height): (u32, u32),
-) -> Result<scaling::Context, ::Error> {
+) -> Result<scaling::Context, crate::Error> {
     scaling::Context::get(
         format, in_width, in_height, format, out_width, out_height, flags,
     )
@@ -18,9 +18,9 @@ pub fn scaler(
 #[inline]
 pub fn converter(
     (width, height): (u32, u32),
-    input: ::format::Pixel,
-    output: ::format::Pixel,
-) -> Result<scaling::Context, ::Error> {
+    input: crate::format::Pixel,
+    output: crate::format::Pixel,
+) -> Result<scaling::Context, crate::Error> {
     scaling::Context::get(
         input,
         width,
@@ -38,9 +38,9 @@ pub mod resampling;
 #[cfg(feature = "software-resampling")]
 #[inline]
 pub fn resampler(
-    (in_format, in_layout, in_rate): (::format::Sample, ::ChannelLayout, u32),
-    (out_format, out_layout, out_rate): (::format::Sample, ::ChannelLayout, u32),
-) -> Result<resampling::Context, ::Error> {
+    (in_format, in_layout, in_rate): (crate::format::Sample, crate::ChannelLayout, u32),
+    (out_format, out_layout, out_rate): (crate::format::Sample, crate::ChannelLayout, u32),
+) -> Result<resampling::Context, crate::Error> {
     resampling::Context::get(
         in_format, in_layout, in_rate, out_format, out_layout, out_rate,
     )

--- a/src/software/resampling/context.rs
+++ b/src/software/resampling/context.rs
@@ -1,12 +1,12 @@
 use std::ptr;
 
 use super::Delay;
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 use std::ffi::c_void;
-use util::format;
-use Dictionary;
-use {frame, ChannelLayout, Error};
+use crate::util::format;
+use crate::Dictionary;
+use crate::{frame, ChannelLayout, Error};
 
 #[derive(Eq, PartialEq, Copy, Clone)]
 pub struct Definition {

--- a/src/software/resampling/context.rs
+++ b/src/software/resampling/context.rs
@@ -2,11 +2,11 @@ use std::ptr;
 
 use super::Delay;
 use crate::ffi::*;
-use libc::c_int;
-use std::ffi::c_void;
 use crate::util::format;
 use crate::Dictionary;
 use crate::{frame, ChannelLayout, Error};
+use libc::c_int;
+use std::ffi::c_void;
 
 #[derive(Eq, PartialEq, Copy, Clone)]
 pub struct Definition {

--- a/src/software/resampling/delay.rs
+++ b/src/software/resampling/delay.rs
@@ -1,5 +1,5 @@
 use super::Context;
-use ffi::*;
+use crate::ffi::*;
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub struct Delay {

--- a/src/software/resampling/dither.rs
+++ b/src/software/resampling/dither.rs
@@ -1,5 +1,5 @@
-use ffi::SwrDitherType::*;
-use ffi::*;
+use crate::ffi::SwrDitherType::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/software/resampling/engine.rs
+++ b/src/software/resampling/engine.rs
@@ -1,7 +1,7 @@
-use ffi::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
-use sys::SwrEngine::*;
+use crate::sys::SwrEngine::*;
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]

--- a/src/software/resampling/engine.rs
+++ b/src/software/resampling/engine.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
+use crate::sys::SwrEngine::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
-use crate::sys::SwrEngine::*;
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]

--- a/src/software/resampling/extensions.rs
+++ b/src/software/resampling/extensions.rs
@@ -1,6 +1,6 @@
 use super::Context;
-use util::format;
-use {decoder, frame, ChannelLayout, Error};
+use crate::util::format;
+use crate::{decoder, frame, ChannelLayout, Error};
 
 impl frame::Audio {
     #[inline]

--- a/src/software/resampling/filter.rs
+++ b/src/software/resampling/filter.rs
@@ -1,5 +1,5 @@
-use ffi::SwrFilterType::*;
-use ffi::*;
+use crate::ffi::SwrFilterType::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/software/resampling/flag.rs
+++ b/src/software/resampling/flag.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 bitflags! {

--- a/src/software/resampling/mod.rs
+++ b/src/software/resampling/mod.rs
@@ -21,7 +21,7 @@ mod extensions;
 use std::ffi::CStr;
 use std::str::from_utf8_unchecked;
 
-use ffi::*;
+use crate::ffi::*;
 
 pub fn version() -> u32 {
     unsafe { swresample_version() }

--- a/src/software/scaling/color_space.rs
+++ b/src/software/scaling/color_space.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};

--- a/src/software/scaling/context.rs
+++ b/src/software/scaling/context.rs
@@ -2,9 +2,9 @@ use std::ptr;
 
 use super::Flags;
 use crate::ffi::*;
-use libc::c_int;
 use crate::util::format;
 use crate::{frame, Error};
+use libc::c_int;
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 pub struct Definition {

--- a/src/software/scaling/context.rs
+++ b/src/software/scaling/context.rs
@@ -1,10 +1,10 @@
 use std::ptr;
 
 use super::Flags;
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
-use util::format;
-use {frame, Error};
+use crate::util::format;
+use crate::{frame, Error};
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 pub struct Definition {

--- a/src/software/scaling/extensions.rs
+++ b/src/software/scaling/extensions.rs
@@ -1,8 +1,8 @@
 use super::{Context, Flags};
-use util::format;
+use crate::util::format;
 #[cfg(not(feature = "ffmpeg_5_0"))]
-use Picture;
-use {decoder, frame, Error};
+use crate::Picture;
+use crate::{decoder, frame, Error};
 
 #[cfg(not(feature = "ffmpeg_5_0"))]
 impl<'a> Picture<'a> {

--- a/src/software/scaling/filter.rs
+++ b/src/software/scaling/filter.rs
@@ -1,5 +1,5 @@
 use super::Vector;
-use ffi::*;
+use crate::ffi::*;
 
 pub struct Filter {
     ptr: *mut SwsFilter,

--- a/src/software/scaling/flag.rs
+++ b/src/software/scaling/flag.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 bitflags! {

--- a/src/software/scaling/mod.rs
+++ b/src/software/scaling/mod.rs
@@ -20,7 +20,7 @@ mod extensions;
 use std::ffi::CStr;
 use std::str::from_utf8_unchecked;
 
-use ffi::*;
+use crate::ffi::*;
 
 pub fn version() -> u32 {
     unsafe { swscale_version() }

--- a/src/software/scaling/support.rs
+++ b/src/software/scaling/support.rs
@@ -1,5 +1,5 @@
-use ffi::*;
-use util::format;
+use crate::ffi::*;
+use crate::util::format;
 
 pub fn input(format: format::Pixel) -> bool {
     unsafe { sws_isSupportedInput(format.into()) != 0 }

--- a/src/software/scaling/vector.rs
+++ b/src/software/scaling/vector.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use std::slice;
 
-use ffi::*;
+use crate::ffi::*;
 use libc::{c_double, c_int};
 
 pub struct Vector<'a> {

--- a/src/util/channel_layout.rs
+++ b/src/util/channel_layout.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_ulonglong;
 
 bitflags! {

--- a/src/util/chroma/location.rs
+++ b/src/util/chroma/location.rs
@@ -1,5 +1,5 @@
-use ffi::AVChromaLocation::*;
-use ffi::*;
+use crate::ffi::AVChromaLocation::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/util/color/primaries.rs
+++ b/src/util/color/primaries.rs
@@ -1,8 +1,8 @@
 use std::ffi::CStr;
 use std::str::from_utf8_unchecked;
 
-use ffi::AVColorPrimaries::*;
-use ffi::*;
+use crate::ffi::AVColorPrimaries::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/util/color/range.rs
+++ b/src/util/color/range.rs
@@ -1,8 +1,8 @@
 use std::ffi::CStr;
 use std::str::from_utf8_unchecked;
 
-use ffi::AVColorRange::*;
-use ffi::*;
+use crate::ffi::AVColorRange::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/util/color/space.rs
+++ b/src/util/color/space.rs
@@ -1,8 +1,8 @@
 use std::ffi::CStr;
 use std::str::from_utf8_unchecked;
 
-use ffi::AVColorSpace::*;
-use ffi::*;
+use crate::ffi::AVColorSpace::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/util/color/transfer_characteristic.rs
+++ b/src/util/color/transfer_characteristic.rs
@@ -1,8 +1,8 @@
 use std::ffi::CStr;
 use std::str::from_utf8_unchecked;
 
-use ffi::AVColorTransferCharacteristic::*;
-use ffi::*;
+use crate::ffi::AVColorTransferCharacteristic::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/util/dictionary/immutable.rs
+++ b/src/util/dictionary/immutable.rs
@@ -5,7 +5,7 @@ use std::ptr;
 use std::str::from_utf8_unchecked;
 
 use super::{Iter, Owned};
-use ffi::*;
+use crate::ffi::*;
 
 pub struct Ref<'a> {
     ptr: *const AVDictionary,

--- a/src/util/dictionary/iter.rs
+++ b/src/util/dictionary/iter.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::ptr;
 use std::str::from_utf8_unchecked;
 
-use ffi::*;
+use crate::ffi::*;
 
 pub struct Iter<'a> {
     ptr: *const AVDictionary,

--- a/src/util/dictionary/mutable.rs
+++ b/src/util/dictionary/mutable.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 
 use super::immutable;
-use ffi::*;
+use crate::ffi::*;
 
 pub struct Ref<'a> {
     ptr: *mut AVDictionary,

--- a/src/util/dictionary/owned.rs
+++ b/src/util/dictionary/owned.rs
@@ -4,7 +4,7 @@ use std::ops::{Deref, DerefMut};
 use std::ptr;
 
 use super::mutable;
-use ffi::*;
+use crate::ffi::*;
 
 pub struct Owned<'a> {
     inner: mutable::Ref<'a>,

--- a/src/util/dictionary/owned.rs
+++ b/src/util/dictionary/owned.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 

--- a/src/util/error.rs
+++ b/src/util/error.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::io;
 use std::str::from_utf8_unchecked;
 
-use ffi::*;
+use crate::ffi::*;
 use libc::{c_char, c_int};
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -3,8 +3,8 @@ use std::ffi::{CStr, CString, NulError};
 use std::fmt;
 use std::str::{from_utf8_unchecked, FromStr};
 
-use ffi::AVPixelFormat::*;
-use ffi::*;
+use crate::ffi::AVPixelFormat::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/util/format/sample.rs
+++ b/src/util/format/sample.rs
@@ -4,8 +4,8 @@ use std::ptr;
 use std::slice;
 use std::str::from_utf8_unchecked;
 
-use ffi::AVSampleFormat::*;
-use ffi::*;
+use crate::ffi::AVSampleFormat::*;
+use crate::ffi::*;
 use libc::{c_int, c_void};
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};

--- a/src/util/frame/audio.rs
+++ b/src/util/frame/audio.rs
@@ -4,9 +4,9 @@ use std::slice;
 
 use super::Frame;
 use crate::ffi::*;
-use libc::{c_int, c_ulonglong};
 use crate::util::format;
 use crate::ChannelLayout;
+use libc::{c_int, c_ulonglong};
 
 #[derive(PartialEq, Eq)]
 pub struct Audio(Frame);

--- a/src/util/frame/audio.rs
+++ b/src/util/frame/audio.rs
@@ -3,10 +3,10 @@ use std::ops::{Deref, DerefMut};
 use std::slice;
 
 use super::Frame;
-use ffi::*;
+use crate::ffi::*;
 use libc::{c_int, c_ulonglong};
-use util::format;
-use ChannelLayout;
+use crate::util::format;
+use crate::ChannelLayout;
 
 #[derive(PartialEq, Eq)]
 pub struct Audio(Frame);

--- a/src/util/frame/flag.rs
+++ b/src/util/frame/flag.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 bitflags! {

--- a/src/util/frame/mod.rs
+++ b/src/util/frame/mod.rs
@@ -10,8 +10,8 @@ pub use self::audio::Audio;
 pub mod flag;
 pub use self::flag::Flags;
 
-use ffi::*;
-use {Dictionary, DictionaryRef};
+use crate::ffi::*;
+use crate::{Dictionary, DictionaryRef};
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub struct Packet {

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -4,11 +4,11 @@ use std::slice;
 use std::str::from_utf8_unchecked;
 
 use super::Frame;
-use ffi::AVFrameSideDataType::*;
-use ffi::*;
+use crate::ffi::AVFrameSideDataType::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
-use DictionaryRef;
+use crate::DictionaryRef;
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -6,9 +6,9 @@ use std::str::from_utf8_unchecked;
 use super::Frame;
 use crate::ffi::AVFrameSideDataType::*;
 use crate::ffi::*;
+use crate::DictionaryRef;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
-use crate::DictionaryRef;
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]

--- a/src/util/frame/video.rs
+++ b/src/util/frame/video.rs
@@ -5,11 +5,11 @@ use std::slice;
 use super::Frame;
 use crate::color;
 use crate::ffi::*;
-use libc::c_int;
 use crate::picture;
 use crate::util::chroma;
 use crate::util::format;
 use crate::Rational;
+use libc::c_int;
 
 #[derive(PartialEq, Eq)]
 pub struct Video(Frame);

--- a/src/util/frame/video.rs
+++ b/src/util/frame/video.rs
@@ -3,13 +3,13 @@ use std::ops::{Deref, DerefMut};
 use std::slice;
 
 use super::Frame;
-use color;
-use ffi::*;
+use crate::color;
+use crate::ffi::*;
 use libc::c_int;
-use picture;
-use util::chroma;
-use util::format;
-use Rational;
+use crate::picture;
+use crate::util::chroma;
+use crate::util::format;
+use crate::Rational;
 
 #[derive(PartialEq, Eq)]
 pub struct Video(Frame);

--- a/src/util/interrupt.rs
+++ b/src/util/interrupt.rs
@@ -1,7 +1,7 @@
 use std::panic;
 use std::process;
 
-use ffi::*;
+use crate::ffi::*;
 use libc::{c_int, c_void};
 
 pub struct Interrupt {

--- a/src/util/log/flag.rs
+++ b/src/util/log/flag.rs
@@ -1,4 +1,4 @@
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 bitflags! {

--- a/src/util/log/level.rs
+++ b/src/util/log/level.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use crate::ffi::*;
 use libc::c_int;
 #[cfg(feature = "serialize")]

--- a/src/util/log/level.rs
+++ b/src/util/log/level.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};

--- a/src/util/log/mod.rs
+++ b/src/util/log/mod.rs
@@ -5,7 +5,6 @@ pub mod flag;
 pub use self::flag::Flags;
 
 use crate::ffi::*;
-use std::convert::TryInto;
 
 pub fn set_level(value: Level) {
     unsafe { av_log_set_level(value.into()) }

--- a/src/util/log/mod.rs
+++ b/src/util/log/mod.rs
@@ -4,7 +4,7 @@ pub use self::level::Level;
 pub mod flag;
 pub use self::flag::Flags;
 
-use ffi::*;
+use crate::ffi::*;
 use std::convert::TryInto;
 
 pub fn set_level(value: Level) {

--- a/src/util/mathematics/rescale.rs
+++ b/src/util/mathematics/rescale.rs
@@ -1,5 +1,5 @@
-use ffi::*;
-use {Rational, Rounding};
+use crate::ffi::*;
+use crate::{Rational, Rounding};
 
 pub const TIME_BASE: Rational = Rational(AV_TIME_BASE_Q.num, AV_TIME_BASE_Q.den);
 

--- a/src/util/mathematics/rounding.rs
+++ b/src/util/mathematics/rounding.rs
@@ -1,5 +1,5 @@
-use ffi::AVRounding::*;
-use ffi::*;
+use crate::ffi::AVRounding::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/util/media.rs
+++ b/src/util/media.rs
@@ -1,5 +1,5 @@
-use ffi::AVMediaType::*;
-use ffi::*;
+use crate::ffi::AVMediaType::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -19,7 +19,7 @@ pub mod time;
 use std::ffi::CStr;
 use std::str::from_utf8_unchecked;
 
-use ffi::*;
+use crate::ffi::*;
 
 #[inline(always)]
 pub fn version() -> u32 {

--- a/src/util/option/mod.rs
+++ b/src/util/option/mod.rs
@@ -1,8 +1,8 @@
 mod traits;
 pub use self::traits::{Gettable, Iterable, Settable, Target};
 
-use ffi::AVOptionType::*;
-use ffi::*;
+use crate::ffi::AVOptionType::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/util/option/traits.rs
+++ b/src/util/option/traits.rs
@@ -4,9 +4,9 @@ use std::ffi::CString;
 use std::mem;
 
 use crate::ffi::*;
-use libc::{c_int, c_void};
 use crate::util::format;
 use crate::{ChannelLayout, Error, Rational};
+use libc::{c_int, c_void};
 
 macro_rules! check {
     ($expr:expr) => {

--- a/src/util/option/traits.rs
+++ b/src/util/option/traits.rs
@@ -3,10 +3,10 @@
 use std::ffi::CString;
 use std::mem;
 
-use ffi::*;
+use crate::ffi::*;
 use libc::{c_int, c_void};
-use util::format;
-use {ChannelLayout, Error, Rational};
+use crate::util::format;
+use crate::{ChannelLayout, Error, Rational};
 
 macro_rules! check {
     ($expr:expr) => {

--- a/src/util/picture.rs
+++ b/src/util/picture.rs
@@ -1,5 +1,5 @@
-use ffi::AVPictureType::*;
-use ffi::*;
+use crate::ffi::AVPictureType::*;
+use crate::ffi::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 

--- a/src/util/rational.rs
+++ b/src/util/rational.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::ops::{Add, Div, Mul, Sub};
 
-use ffi::*;
+use crate::ffi::*;
 use libc::c_int;
 
 #[derive(Copy, Clone)]

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -1,5 +1,5 @@
-use ffi::*;
-use Error;
+use crate::ffi::*;
+use crate::Error;
 
 #[inline(always)]
 pub fn current() -> i64 {


### PR DESCRIPTION
The migration consists of (only) these changes:
- Add `crate::` prefix to crate-local `use ...` statements
- Add `edition = "2021"` to both crates
- Fix new clippy warnings (new prelude = some redundant imports)
- `cargo fmt`