### PR TITLE
Remove num_cpus build dependency

### DIFF
--- a/ffmpeg-sys-the-third/Cargo.toml
+++ b/ffmpeg-sys-the-third/Cargo.toml
@@ -24,7 +24,6 @@ doctest = false
 libc = "0.2"
 
 [build-dependencies]
-num_cpus = "1.11"
 cc = "1.0"
 pkg-config = "0.3"
 bindgen = { version = "0.64", default-features = false, features = ["runtime"] }

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -1,6 +1,5 @@
 extern crate bindgen;
 extern crate cc;
-extern crate num_cpus;
 extern crate pkg_config;
 
 use std::env;
@@ -465,10 +464,15 @@ fn build() -> io::Result<()> {
         ));
     }
 
+    let num_jobs = if let Ok(cpus) = std::thread::available_parallelism() {
+        cpus.to_string()
+    } else {
+        "1".to_string()
+    };
+
     // run make
     if !Command::new("make")
-        .arg("-j")
-        .arg(num_cpus::get().to_string())
+        .arg(format!("-j{num_jobs}"))
         .current_dir(&source())
         .status()?
         .success()


### PR DESCRIPTION
`std::thread::available_parallelism` is stable since Rust 1.59.0, so no MSRV concerns.