### PR TITLE
Run sys (bindgen) tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,11 @@ env:
     -F codec,device,filter,format
     -F software-resampling,software-scaling"
 
+  SYS_FEATURES: "
+    --no-default-features
+    --features avcodec,avdevice,avfilter,avformat
+    --features swresample,swscale"
+
 jobs:
   build-test-lint-linux:
     name: Linux - FFmpeg ${{ matrix.ffmpeg_version }} - build, test and lint
@@ -49,6 +54,12 @@ jobs:
         run: cargo clippy --all-targets $CARGO_FEATURES
       - name: Build
         run: cargo build --all-targets $CARGO_FEATURES
+      - name: Test bindings
+        run: >
+          cargo test
+          --manifest-path ffmpeg-sys-the-third/Cargo.toml
+          --target-dir target
+          $SYS_FEATURES
       - name: Test
         run: cargo test $CARGO_FEATURES
 
@@ -71,6 +82,12 @@ jobs:
         run: cargo clippy --all-targets $CARGO_FEATURES
       - name: Build
         run: cargo build --all-targets $CARGO_FEATURES
+      - name: Test bindings
+        run: >
+          cargo test
+          --manifest-path ffmpeg-sys-the-third/Cargo.toml
+          --target-dir target
+          $SYS_FEATURES
       - name: Test
         run: cargo test $CARGO_FEATURES
 
@@ -110,6 +127,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: "v1-rust"
           save-if: ${{ matrix.ffmpeg_version == '6.1' }}
 
       - name: Check format
@@ -118,5 +136,11 @@ jobs:
         run: cargo clippy --all-targets $CARGO_FEATURES
       - name: Build
         run: cargo build --all-targets $CARGO_FEATURES
+      - name: Test bindings
+        run: >
+          cargo test
+          --manifest-path ffmpeg-sys-the-third/Cargo.toml
+          --target-dir target
+          $SYS_FEATURES
       - name: Test
         run: cargo test $CARGO_FEATURES


### PR DESCRIPTION
This was an oversight in the CI up until now.

The tests in bindings.rs are actually very important to guarantee that assumptions in Rust code are met. Unsafe code has a lot of requirements regarding alignment and such, and these tests verify them.

A shortened example showing `AVCodec` tests:

```rs
#[repr(C)]
#[derive(Debug /*, ... */)]
pub struct AVCodec {
  pub name: *const libc::c_char,
  // ...
}
```

```rs
#[test]
fn bindgen_test_layout_AVCodec() {
    const UNINIT: ::std::mem::MaybeUninit<AVCodec> = ::std::mem::MaybeUninit::uninit();
    let ptr = UNINIT.as_ptr();
    assert_eq!(
        ::std::mem::size_of::<AVCodec>(),
        104usize,
        concat!("Size of: ", stringify!(AVCodec))
    );
    assert_eq!(
        ::std::mem::align_of::<AVCodec>(),
        8usize,
        concat!("Alignment of ", stringify!(AVCodec))
    );
    assert_eq!(
        unsafe { ::std::ptr::addr_of!((*ptr).name) as usize - ptr as usize },
        0usize,
        concat!(
            "Offset of field: ",
            stringify!(AVCodec),
            "::",
            stringify!(name)
        )
    );

    // ...
}
```