### PR TITLE
New FF_API_ flags

### DIFF
--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -82,6 +82,15 @@ static AVUTIL_FEATURES: &[AVFeature] = &[
     AVFeature::new("FIFO_OLD_API"),
     AVFeature::new("OLD_CHANNEL_LAYOUT"),
     AVFeature::new("AV_FOPEN_UTF8"),
+    AVFeature::new("PKT_DURATION"),
+    AVFeature::new("REORDERED_OPAQUE"),
+    AVFeature::new("FRAME_PICTURE_NUMBER"),
+    AVFeature::new("HDR_VIVID_THREE_SPLINE"),
+    AVFeature::new("FRAME_PKT"),
+    AVFeature::new("INTERLACED_FRAME"),
+    AVFeature::new("FRAME_KEY"),
+    AVFeature::new("PALETTE_HAS_CHANGED"),
+    AVFeature::new("VULKAN_CONTIGUOUS_MEMORY"),
 ];
 
 static AVCODEC_FEATURES: &[AVFeature] = &[
@@ -156,6 +165,17 @@ static AVCODEC_FEATURES: &[AVFeature] = &[
     AVFeature::new("SUB_TEXT_FORMAT"),
     AVFeature::new("IDCT_NONE"),
     AVFeature::new("SVTAV1_OPTS"),
+    AVFeature::new("AYUV_CODECID"),
+    AVFeature::new("VT_OUTPUT_CALLBACK"),
+    AVFeature::new("AVCODEC_CHROMA_POS"),
+    AVFeature::new("VT_HWACCEL_CONTEXT"),
+    AVFeature::new("AVCTX_FRAME_NUMBER"),
+    AVFeature::new("SLICE_OFFSET"),
+    AVFeature::new("SUBFRAMES"),
+    AVFeature::new("TICKS_PER_FRAME"),
+    AVFeature::new("DROPCHANGED"),
+    AVFeature::new("AVFFT"),
+    AVFeature::new("FF_PROFILE_LEVEL"),
 ];
 
 static AVFORMAT_FEATURES: &[AVFeature] = &[
@@ -170,6 +190,13 @@ static AVFORMAT_FEATURES: &[AVFeature] = &[
     AVFeature::new("AVIOCONTEXT_WRITTEN"),
     AVFeature::new("AVSTREAM_CLASS"),
     AVFeature::new("R_FRAME_RATE"),
+    AVFeature::new("GET_END_PTS"),
+    AVFeature::new("AVIODIRCONTEXT"),
+    AVFeature::new("AVFORMAT_IO_CLOSE"),
+    AVFeature::new("AVIO_WRITE_NONCONST"),
+    AVFeature::new("LAVF_SHORTEST"),
+    AVFeature::new("ALLOW_FLUSH"),
+    AVFeature::new("AVSTREAM_SIDE_DATA"),
 ];
 
 static AVDEVICE_FEATURES: &[AVFeature] = &[AVFeature::new("DEVICE_CAPABILITIES")];
@@ -186,6 +213,7 @@ static AVFILTER_FEATURES: &[AVFeature] = &[
     AVFeature::new("SWS_PARAM_OPTION"),
     AVFeature::new("BUFFERSINK_ALLOC"),
     AVFeature::new("PAD_COUNT"),
+    AVFeature::new("LIBPLACEBO_OPTS"),
 ];
 
 static AVRESAMPLE_FEATURES: &[AVFeature] = &[AVFeature::new("RESAMPLE_CLOSE_OPEN")];

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -74,6 +74,14 @@ static AVUTIL_FEATURES: &[AVFeature] = &[
     AVFeature::new("PKT_PTS"),
     AVFeature::new("ERROR_FRAME"),
     AVFeature::new("FRAME_QP"),
+    AVFeature::new("D2STR"),
+    AVFeature::new("DECLARE_ALIGNED"),
+    AVFeature::new("COLORSPACE_NAME"),
+    AVFeature::new("AV_MALLOCZ_ARRAY"),
+    AVFeature::new("FIFO_PEEK2"),
+    AVFeature::new("FIFO_OLD_API"),
+    AVFeature::new("OLD_CHANNEL_LAYOUT"),
+    AVFeature::new("AV_FOPEN_UTF8"),
 ];
 
 static AVCODEC_FEATURES: &[AVFeature] = &[
@@ -137,6 +145,17 @@ static AVCODEC_FEATURES: &[AVFeature] = &[
     AVFeature::new("VBV_DELAY"),
     AVFeature::new("SIDEDATA_ONLY_PKT"),
     AVFeature::new("AVPICTURE"),
+    AVFeature::new("OPENH264_SLICE_MODE"),
+    AVFeature::new("OPENH264_CABAC"),
+    AVFeature::new("UNUSED_CODEC_CAPS"),
+    AVFeature::new("THREAD_SAFE_CALLBACKS"),
+    AVFeature::new("GET_FRAME_CLASS"),
+    AVFeature::new("AUTO_THREADS"),
+    AVFeature::new("INIT_PACKET"),
+    AVFeature::new("FLAG_TRUNCATED"),
+    AVFeature::new("SUB_TEXT_FORMAT"),
+    AVFeature::new("IDCT_NONE"),
+    AVFeature::new("SVTAV1_OPTS"),
 ];
 
 static AVFORMAT_FEATURES: &[AVFeature] = &[
@@ -146,9 +165,14 @@ static AVFORMAT_FEATURES: &[AVFeature] = &[
     AVFeature::new("PROBESIZE_32"),
     AVFeature::new("LAVF_AVCTX"),
     AVFeature::new("OLD_OPEN_CALLBACKS"),
+    AVFeature::new("LAVF_PRIV_OPT"),
+    AVFeature::new("COMPUTE_PKT_FIELDS2"),
+    AVFeature::new("AVIOCONTEXT_WRITTEN"),
+    AVFeature::new("AVSTREAM_CLASS"),
+    AVFeature::new("R_FRAME_RATE"),
 ];
 
-static AVDEVICE_FEATURES: &[AVFeature] = &[];
+static AVDEVICE_FEATURES: &[AVFeature] = &[AVFeature::new("DEVICE_CAPABILITIES")];
 
 static AVFILTER_FEATURES: &[AVFeature] = &[
     AVFeature::new("AVFILTERPAD_PUBLIC"),
@@ -159,6 +183,9 @@ static AVFILTER_FEATURES: &[AVFeature] = &[
     AVFeature::new("OLD_FILTER_REGISTER"),
     AVFeature::new("OLD_GRAPH_PARSE"),
     AVFeature::new("NOCONST_GET_NAME"),
+    AVFeature::new("SWS_PARAM_OPTION"),
+    AVFeature::new("BUFFERSINK_ALLOC"),
+    AVFeature::new("PAD_COUNT"),
 ];
 
 static AVRESAMPLE_FEATURES: &[AVFeature] = &[AVFeature::new("RESAMPLE_CLOSE_OPEN")];


### PR DESCRIPTION
I noticed that quite a lot were missing. I assume they were kept up to date until 4.4, and then went back and diffed the `version.h` and `version_major.h` files `n4.4...n5.1.4`, `n5.1.4...n6.1.1`.

Now that I'm noticing all this upkeep, it might make sense to create a checklist for when a new FFmpeg major version is released.