### PR TITLE
Avoid using "static" functions in build script

### DIFF
--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -338,16 +338,16 @@ fn search() -> PathBuf {
     absolute
 }
 
-fn fetch() -> io::Result<()> {
+fn fetch(ffmpeg_version: &str) -> io::Result<()> {
     let output_base_path = output();
-    let clone_dest_dir = format!("ffmpeg-{}", ffmpeg_version());
+    let clone_dest_dir = format!("ffmpeg-{ffmpeg_version}");
     let _ = std::fs::remove_dir_all(output_base_path.join(&clone_dest_dir));
     let status = Command::new("git")
         .current_dir(&output_base_path)
         .arg("clone")
         .arg("--depth=1")
         .arg("-b")
-        .arg(format!("n{}", ffmpeg_version()))
+        .arg(format!("n{ffmpeg_version}"))
         .arg("https://github.com/FFmpeg/FFmpeg")
         .arg(&clone_dest_dir)
         .status()?;
@@ -414,12 +414,12 @@ static EXTERNAL_BUILD_LIBS: &[(&str, &str)] = &[
     ("SSH", "libssh"),
 ];
 
-fn build() -> io::Result<()> {
+fn build(ffmpeg_version: &str) -> io::Result<()> {
     if search().join("lib").join("libavutil.a").exists() {
         return Ok(());
     }
 
-    fetch()?;
+    fetch(ffmpeg_version)?;
 
     let source_dir = source();
 
@@ -830,10 +830,11 @@ fn link_to_libraries(statik: bool) {
 
 fn main() {
     let statik = cargo_feature_enabled("static");
+    let ffmpeg_version = ffmpeg_version();
     let ffmpeg_major_version: u32 = ffmpeg_major_version();
 
     let include_paths: Vec<PathBuf> = if cargo_feature_enabled("build") {
-        build().unwrap();
+        build(&ffmpeg_version).unwrap();
         println!(
             "cargo:rustc-link-search=native={}",
             search().join("lib").to_string_lossy()

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -318,8 +318,8 @@ fn ffmpeg_version() -> String {
         .replace("ffmpeg-", "")
 }
 
-fn ffmpeg_major_version() -> u32 {
-    ffmpeg_version().split('.').next().unwrap().parse().unwrap()
+fn get_major_version(version_string: &str) -> u32 {
+    version_string.split('.').next().unwrap().parse().unwrap()
 }
 
 fn output() -> PathBuf {
@@ -468,7 +468,7 @@ fn build(out_dir: &Path, ffmpeg_version: &str) -> io::Result<PathBuf> {
     // the binary using ffmpeg-sys cannot be redistributed
     configure.switch("BUILD_LICENSE_NONFREE", "nonfree");
 
-    let ffmpeg_major_version: u32 = ffmpeg_major_version();
+    let ffmpeg_major_version: u32 = get_major_version(ffmpeg_version);
 
     // configure building libraries based on features
     for lib in LIBRARIES
@@ -839,7 +839,7 @@ fn main() {
     let out_dir = output();
     let statik = cargo_feature_enabled("static");
     let ffmpeg_version = ffmpeg_version();
-    let ffmpeg_major_version: u32 = ffmpeg_major_version();
+    let ffmpeg_major_version: u32 = get_major_version(&ffmpeg_version);
 
     let include_paths: Vec<PathBuf> = if cargo_feature_enabled("build") {
         let install_dir = build(&out_dir, &ffmpeg_version).unwrap();

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -415,6 +415,12 @@ static EXTERNAL_BUILD_LIBS: &[(&str, &str)] = &[
 ];
 
 fn build() -> io::Result<()> {
+    if search().join("lib").join("libavutil.a").exists() {
+        return Ok(());
+    }
+
+    fetch()?;
+
     let source_dir = source();
 
     // Command's path is not relative to command's current_dir
@@ -827,16 +833,12 @@ fn main() {
     let ffmpeg_major_version: u32 = ffmpeg_major_version();
 
     let include_paths: Vec<PathBuf> = if cargo_feature_enabled("build") {
+        build().unwrap();
         println!(
             "cargo:rustc-link-search=native={}",
             search().join("lib").to_string_lossy()
         );
         link_to_libraries(statik);
-        if fs::metadata(search().join("lib").join("libavutil.a")).is_err() {
-            fs::create_dir_all(output()).expect("failed to create build directory");
-            fetch().unwrap();
-            build().unwrap();
-        }
 
         // Check additional required libraries.
         {

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -577,8 +577,6 @@ fn try_vcpkg(statik: bool) -> Option<Vec<PathBuf>> {
 // add well known package manager lib paths us as homebrew (or macports)
 #[cfg(target_os = "macos")]
 fn add_pkg_config_path() {
-    use std::path::Path;
-
     let pc_path = pkg_config::get_variable("pkg-config", "pc_path").unwrap();
     // append M1 homebrew pkgconfig path
     let brew_pkgconfig = cfg!(target_arch = "aarch64")

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -413,7 +413,8 @@ static EXTERNAL_BUILD_LIBS: &[(&str, &str)] = &[
 
 fn build(ffmpeg_version: &str) -> io::Result<()> {
     let source_dir = source();
-    if search().join("lib").join("libavutil.a").exists() {
+    let install_dir = search();
+    if install_dir.join("lib").join("libavutil.a").exists() {
         rustc_link_extralibs(&source_dir);
         return Ok(());
     }
@@ -426,7 +427,7 @@ fn build(ffmpeg_version: &str) -> io::Result<()> {
     let mut configure = Command::new(&configure_path);
     configure.current_dir(&source_dir);
 
-    configure.arg(format!("--prefix={}", search().to_string_lossy()));
+    configure.arg(format!("--prefix={}", install_dir.to_string_lossy()));
 
     if env::var("TARGET").unwrap() != env::var("HOST").unwrap() {
         // Rust targets are subtly different than naming scheme for compiler prefixes.


### PR DESCRIPTION
The high number of commits is for review's sake, they should probably be squashed if & when merging.

Having `search()`, `source()`, `output()` calls scattered around the script seems not great to me. It's pretty easy to have internal consistency when passing parameters to `build()` and other functions.