### PR TITLE
Add CI matrix for macOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
 
     env:
-      PKG_CONFIG_PATH: /usr/local/opt/ffmpeg@${{ matrix.ffmpeg_version }}/lib/pkgconfig
+      PKG_CONFIG_PATH: /opt/homebrew/opt/ffmpeg@${{ matrix.ffmpeg_version }}/lib/pkgconfig
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: "0 0 * * *" # Daily
+    - cron: "20 7 * * 4" # Weekly on thursday 
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,12 +64,17 @@ jobs:
         run: cargo test $CARGO_FEATURES
 
   build-test-lint-macos:
-    name: macOS - FFmpeg latest - build, test and lint
+    name: macOS - FFmpeg ${{ matrix.ffmpeg_version }} - build, test and lint
     runs-on: macos-latest
+    strategy:
+      matrix:
+        ffmpeg_version: ["4", "5", "6"]
+      fail-fast: false
+
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: brew install ffmpeg pkg-config
+        run: brew install ffmpeg@${{ matrix.ffmpeg_version }} pkg-config
       - name: Install Rust stable with clippy and rustfmt
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,9 @@ jobs:
         ffmpeg_version: ["4", "5", "6"]
       fail-fast: false
 
+    env:
+      PKG_CONFIG_PATH: /usr/local/opt/ffmpeg@${{ matrix.ffmpeg_version }}/lib/pkgconfig
+
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies


### PR DESCRIPTION
homebrew has rudimentary version support by specifying `ffmpeg@4`, `ffmpeg@5` etc. No minor/patch versions AFAICT.

Also reduced the frequency of scheduled builds. Daily is just too much. Caches should stay alive for 7 days at least, so this should not cause problems regarding cache. Time and day are chosen semi-randomly (but moved away from midnight because that is a known hot time for CI jobs)