### PR TITLE
Fix avfiltergraph input output

### DIFF
--- a/src/filter/graph.rs
+++ b/src/filter/graph.rs
@@ -217,6 +217,15 @@ fn append_inout(list: &mut *mut AVFilterInOut, element: NonNull<AVFilterInOut>) 
     }
 }
 
+impl<'a> Drop for Parser<'a> {
+    fn drop(&mut self) {
+        unsafe {
+            avfilter_inout_free(&mut self.inputs);
+            avfilter_inout_free(&mut self.outputs);
+        }
+    }
+}
+
 impl Default for Graph {
     fn default() -> Self {
         Self::new()

--- a/src/filter/graph.rs
+++ b/src/filter/graph.rs
@@ -1,5 +1,5 @@
 use std::ffi::{CStr, CString};
-use std::ptr;
+use std::ptr::{self, NonNull};
 use std::str::from_utf8_unchecked;
 
 use super::{Context, Filter};
@@ -145,24 +145,16 @@ impl<'a> Parser<'a> {
     pub fn input(mut self, name: &str, pad: usize) -> Result<Self, Error> {
         unsafe {
             let mut context = self.graph.get(name).ok_or(Error::InvalidData)?;
-            let input = avfilter_inout_alloc();
-
-            if input.is_null() {
-                panic!("out of memory");
-            }
+            let mut input = NonNull::new(avfilter_inout_alloc()).expect("out of memory");
 
             let name = CString::new(name).unwrap();
 
-            (*input).name = av_strdup(name.as_ptr());
-            (*input).filter_ctx = context.as_mut_ptr();
-            (*input).pad_idx = pad as c_int;
-            (*input).next = ptr::null_mut();
+            input.as_mut().name = av_strdup(name.as_ptr());
+            input.as_mut().filter_ctx = context.as_mut_ptr();
+            input.as_mut().pad_idx = pad as c_int;
+            input.as_mut().next = ptr::null_mut();
 
-            if self.inputs.is_null() {
-                self.inputs = input;
-            } else {
-                (*self.inputs).next = input;
-            }
+            append_inout(&mut self.inputs, input);
         }
 
         Ok(self)
@@ -171,24 +163,16 @@ impl<'a> Parser<'a> {
     pub fn output(mut self, name: &str, pad: usize) -> Result<Self, Error> {
         unsafe {
             let mut context = self.graph.get(name).ok_or(Error::InvalidData)?;
-            let output = avfilter_inout_alloc();
-
-            if output.is_null() {
-                panic!("out of memory");
-            }
+            let mut output = NonNull::new(avfilter_inout_alloc()).expect("out of memory");
 
             let name = CString::new(name).unwrap();
 
-            (*output).name = av_strdup(name.as_ptr());
-            (*output).filter_ctx = context.as_mut_ptr();
-            (*output).pad_idx = pad as c_int;
-            (*output).next = ptr::null_mut();
+            output.as_mut().name = av_strdup(name.as_ptr());
+            output.as_mut().filter_ctx = context.as_mut_ptr();
+            output.as_mut().pad_idx = pad as c_int;
+            output.as_mut().next = ptr::null_mut();
 
-            if self.outputs.is_null() {
-                self.outputs = output;
-            } else {
-                (*self.outputs).next = output;
-            }
+            append_inout(&mut self.outputs, output);
         }
 
         Ok(self)
@@ -214,6 +198,22 @@ impl<'a> Parser<'a> {
                 e => Err(Error::from(e)),
             }
         }
+    }
+}
+
+fn append_inout(list: &mut *mut AVFilterInOut, element: NonNull<AVFilterInOut>) {
+    unsafe {
+        if list.is_null() {
+            *list = element.as_ptr();
+            return;
+        }
+
+        let mut curr = *list;
+        while !(*curr).next.is_null() {
+            curr = (*curr).next;
+        }
+
+        (*curr).next = element.as_ptr();
     }
 }
 


### PR DESCRIPTION
Upstream got a bug report: zmwangx/rust-ffmpeg#177.

Properly support appending new `AVFilterInOut`s to the input/output lists instead of just rewriting the first element over and over.

Also add a proper `Drop` implementation.

Looks like macOS CI will keep on failing (until CI change) because it's downloading FFmpeg 7.0.