### PR TITLE
Don't tell brew to install pkg-config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: brew install ffmpeg@${{ matrix.ffmpeg_version }} pkg-config
+        run: brew install ffmpeg@${{ matrix.ffmpeg_version }}
       - name: Install Rust stable with clippy and rustfmt
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
It's preinstalled on GHA runners and [causes a CI warning](https://github.com/shssoichiro/ffmpeg-the-third/actions/runs/9128422452).