### PR TITLE
Don't assume that `c_char` is an `i8`

### DIFF
--- a/ffmpeg-sys-the-third/src/avutil/channel_layout.rs
+++ b/ffmpeg-sys-the-third/src/avutil/channel_layout.rs
@@ -311,6 +311,7 @@ pub const AV_CHANNEL_LAYOUT_7POINT1_TOP_BACK: AVChannelLayout =
 #[cfg(test)]
 mod test {
     use super::*;
+    use libc::c_char;
 
     // TODO: Missing: Ambisonic layout
 
@@ -330,15 +331,15 @@ mod test {
     };
 
     // TODO: Replace with cstr literals when MSRV is 1.77
-    const fn c_string<const N: usize, const K: usize>(byte_str: &[u8; N]) -> [i8; K] {
+    const fn c_string<const N: usize, const K: usize>(byte_str: &[u8; N]) -> [c_char; K] {
         // Need at least one NUL byte at the end
         assert!(N < K, "input string is too long (max 15 char)");
 
-        let mut result = [0i8; K];
+        let mut result = [0; K];
         let mut i = 0;
 
         while i < N {
-            result[i] = byte_str[i] as i8;
+            result[i] = byte_str[i] as c_char;
             i += 1;
         }
 

--- a/src/util/channel_layout/channel_custom.rs
+++ b/src/util/channel_layout/channel_custom.rs
@@ -1,3 +1,5 @@
+use libc::c_char;
+
 use crate::ffi::{AVChannel, AVChannelCustom};
 
 use super::Channel;
@@ -30,12 +32,12 @@ impl ChannelCustom {
     }
 }
 
-fn to_char_array(bytes: &[u8]) -> [i8; 16] {
-    let mut result = [0i8; 16];
+fn to_char_array(bytes: &[u8]) -> [c_char; 16] {
+    let mut result = [0; 16];
 
     // Only take the first 15 bytes, leaving at least one NUL byte
     for (b, r) in bytes.iter().take(15).zip(&mut result) {
-        *r = *b as i8;
+        *r = *b as c_char;
     }
 
     result


### PR DESCRIPTION
See #63. @jbeich This builds on my machine, but could you verify that the tests pass on an affected platform?

I'll try to add something to CI after this