### PR TITLE
Print libclang version in build.rs

### DIFF
--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -719,6 +719,8 @@ fn check_features(include_paths: &[PathBuf]) {
     let clang = clang::Clang::new().expect("Cannot find clang");
     let index = clang::Index::new(&clang, false, false);
 
+    println!("loaded clang version: {}", clang::get_version());
+
     let enabled_libraries = || LIBRARIES.iter().filter(|lib| lib.enabled());
 
     let mut code = String::new();


### PR DESCRIPTION
Should be helpful to identify build failures related to clang. Might be useful for #65 (which I can't repro on my fork atm).