### PR TITLE
Add `rustc-check-cfg` for `ffmpeg_x_y` features

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,14 @@ use std::env;
 
 fn main() {
     for (name, _value) in env::vars() {
-        if name.starts_with("DEP_FFMPEG_") {
+        println!("{name}");
+
+        if name.starts_with("DEP_FFMPEG_CHECK_") {
+            println!(
+                r#"cargo:rustc-check-cfg=cfg(feature, values("{}"))"#,
+                name["DEP_FFMPEG_CHECK_".len()..name.len()].to_lowercase()
+            );
+        } else if name.starts_with("DEP_FFMPEG_") {
             println!(
                 r#"cargo:rustc-cfg=feature="{}""#,
                 name["DEP_FFMPEG_".len()..name.len()].to_lowercase()

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -851,6 +851,9 @@ fn check_features(include_paths: &[PathBuf]) {
         .expect("Unable to find the version for lib{lib}");
 
     for &(ffmpeg_version_flag, lavc_version_major, lavc_version_minor) in &ffmpeg_lavc_versions {
+        // Every possible feature needs an unconditional check-cfg to prevent warnings
+        println!(r#"cargo:rustc-check-cfg=cfg(feature, values("{}"))"#, ffmpeg_version_flag);
+
         if lavc_version >= (lavc_version_major, lavc_version_minor) {
             println!(r#"cargo:rustc-cfg=feature="{}""#, ffmpeg_version_flag);
             println!(r#"cargo:{}=true"#, ffmpeg_version_flag);

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -853,6 +853,7 @@ fn check_features(include_paths: &[PathBuf]) {
     for &(ffmpeg_version_flag, lavc_version_major, lavc_version_minor) in &ffmpeg_lavc_versions {
         // Every possible feature needs an unconditional check-cfg to prevent warnings
         println!(r#"cargo:rustc-check-cfg=cfg(feature, values("{}"))"#, ffmpeg_version_flag);
+        println!(r#"cargo:check_{}=true"#, ffmpeg_version_flag);
 
         if lavc_version >= (lavc_version_major, lavc_version_minor) {
             println!(r#"cargo:rustc-cfg=feature="{}""#, ffmpeg_version_flag);


### PR DESCRIPTION
See #58. This change does not fix all warnings, but most of them.

I'm not sure how other `-sys` crates handle this..