### PR TITLE
CI: Avoid docker containers in favor of prebuilt binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,14 +35,19 @@ jobs:
             file: "ffmpeg-4.3-linux-gcc.tar.xz"
           - version: "4.4"
             file: "ffmpeg-4.4-linux-clang-default.tar.xz"
+            lib_subdir: "amd64"
           - version: "5.1"
             file: "ffmpeg-5.1-linux-clang-default.tar.xz"
+            lib_subdir: "amd64"
           - version: "6.1"
             file: "ffmpeg-6.1-linux-clang-default.tar.xz"
+            lib_subdir: "amd64"
           - version: "7.0"
             file: "ffmpeg-7.0-linux-clang-default.tar.xz"
+            lib_subdir: "amd64"
           - version: "7.1"
             file: "ffmpeg-7.1-linux-clang-default.tar.xz"
+            lib_subdir: "amd64"
       fail-fast: false
 
     steps:
@@ -53,11 +58,19 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
                                libva2 libva-drm2 libva-x11-2 libvdpau1 libxv1
       - name: Download FFmpeg
+        shell: bash
         run: |
           mkdir ffmpeg-libs
           curl -L "https://sourceforge.net/projects/avbuild/files/linux/${{ matrix.ffmpeg.file }}/download" \
             | tar xJf - --strip 1 -C ffmpeg-libs
-          echo "PKG_CONFIG_PATH=$PWD/ffmpeg-libs/lib/amd64/pkgconfig" >> "$GITHUB_ENV"
+
+          # https://github.com/wang-bin/avbuild/issues/76
+          PC_FILES=(ffmpeg-libs/lib/${{ matrix.ffmpeg.lib_subdir }}/pkgconfig/*.pc)
+          sed -i 's/^prefix=.*$/prefix=${pcfiledir}\/..\/..\/../g' $PC_FILES
+          sed -i 's/^libdir=.*$/libdir=${prefix}\/lib\/${{ matrix.ffmpeg.lib_subdir }}/g' $PC_FILES
+
+          echo "PKG_CONFIG_PATH=$PWD/ffmpeg-libs/lib/${{ matrix.ffmpeg.lib_subdir }}/pkgconfig" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$PWD/ffmpeg-libs/lib/${{ matrix.ffmpeg.lib_subdir }}" >> "$GITHUB_ENV"
       - name: Install Rust stable with clippy and rustfmt
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -181,11 +194,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download FFmpeg
+        shell: bash
         run: |
           mkdir ffmpeg-libs
           curl -L "https://sourceforge.net/projects/avbuild/files/linux/ffmpeg-7.1-linux-clang-lite.tar.xz/download" \
             | tar xJf - --strip 1 -C ffmpeg-libs
+
+          # https://github.com/wang-bin/avbuild/issues/76
+          PC_FILES=(ffmpeg-libs/lib/amd64/pkgconfig/*.pc)
+          sed -i 's/^prefix=.*$/prefix=${pcfiledir}\/..\/..\/../g' $PC_FILES
+          sed -i 's/^libdir=.*$/libdir=${prefix}\/lib\/amd64/g' $PC_FILES
+
           echo "PKG_CONFIG_PATH=$PWD/ffmpeg-libs/lib/amd64/pkgconfig" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$PWD/ffmpeg-libs" >> "$GITHUB_ENV"
       # rust-version from Cargo.toml
       - name: Install Rust 1.65.0
         uses: dtolnay/rust-toolchain@1.65.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,30 +23,41 @@ env:
 
 jobs:
   build-test-lint-linux:
-    name: Linux - FFmpeg ${{ matrix.ffmpeg_version }} - build, test and lint
+    name: Linux - FFmpeg ${{ matrix.ffmpeg.version }} - build, test and lint
     runs-on: ubuntu-22.04
-    container: jrottenberg/ffmpeg:${{ matrix.ffmpeg_version }}-ubuntu
 
     strategy:
       matrix:
-        ffmpeg_version:
-          - "4.2"
-          - "4.3"
-          - "4.4"
-          - "5.0"
-          - "5.1"
-          - "6.0"
-          - "6.1"
-          - "7.0"
-          - "7.1"
+        ffmpeg:
+          - version: "4.2"
+            file: "ffmpeg-4.2-linux-gcc.tar.xz"
+          - version: "4.3"
+            file: "ffmpeg-4.3-linux-gcc.tar.xz"
+          - version: "4.4"
+            file: "ffmpeg-4.4-linux-clang-default.tar.xz"
+          - version: "5.1"
+            file: "ffmpeg-5.1-linux-clang-default.tar.xz"
+          - version: "6.1"
+            file: "ffmpeg-6.1-linux-clang-default.tar.xz"
+          - version: "7.0"
+            file: "ffmpeg-7.0-linux-clang-default.tar.xz"
+          - version: "7.1"
+            file: "ffmpeg-7.1-linux-clang-default.tar.xz"
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          apt-get update
-          apt-get install -y --no-install-recommends clang curl pkg-config
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+                               libva2 libva-drm2 libva-x11-2 libvdpau1 libxv1
+      - name: Download FFmpeg
+        run: |
+          mkdir ffmpeg-libs
+          curl -L "https://sourceforge.net/projects/avbuild/files/linux/${{ matrix.ffmpeg.file }}/download" \
+            | tar xJf - --strip 1 -C ffmpeg-libs
+          echo "PKG_CONFIG_PATH=$PWD/ffmpeg-libs/lib/amd64/pkgconfig" >> "$GITHUB_ENV"
       - name: Install Rust stable with clippy and rustfmt
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -55,7 +66,7 @@ jobs:
         with:
           prefix-key: "v3-rust"
           # Only save cache for one FFmpeg version
-          save-if: ${{ matrix.ffmpeg_version == '7.1' }}
+          save-if: ${{ matrix.ffmpeg.version == '7.1' }}
 
       - name: Check format
         run: cargo fmt -- --check
@@ -166,14 +177,15 @@ jobs:
 
   msrv:
     runs-on: ubuntu-22.04
-    container: jrottenberg/ffmpeg:7.0-ubuntu
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
+      - name: Download FFmpeg
         run: |
-          apt-get update
-          apt-get install -y --no-install-recommends clang curl pkg-config
+          mkdir ffmpeg-libs
+          curl -L "https://sourceforge.net/projects/avbuild/files/linux/ffmpeg-7.1-linux-clang-lite.tar.xz/download" \
+            | tar xJf - --strip 1 -C ffmpeg-libs
+          echo "PKG_CONFIG_PATH=$PWD/ffmpeg-libs/lib/amd64/pkgconfig" >> "$GITHUB_ENV"
       # rust-version from Cargo.toml
       - name: Install Rust 1.65.0
         uses: dtolnay/rust-toolchain@1.65.0

--- a/src/codec/config.rs
+++ b/src/codec/config.rs
@@ -46,11 +46,11 @@ where
     /// # Example
     ///
     /// ```
-    /// use ffmpeg_the_third::codec::{encoder, Id};
+    /// use ffmpeg_the_third::codec::{decoder, Id};
     /// use ffmpeg_the_third::format::sample::{Sample, Type};
     ///
-    /// let codec = encoder::find(Id::MP3)
-    ///     .expect("Can find an MP3 encoder")
+    /// let codec = decoder::find(Id::MP3)
+    ///     .expect("Can find an MP3 decoder")
     ///     .audio()
     ///     .unwrap();
     ///
@@ -297,7 +297,7 @@ mod test {
 
     #[test]
     fn audio_encoder() {
-        let codec = encoder::find(Id::MP3).expect("can find mp3 encoder");
+        let codec = encoder::find(Id::OPUS).expect("can find opus encoder");
 
         // looks like every codec returns Supported::All for color space.
         // might change in a future FFmpeg release
@@ -352,15 +352,15 @@ mod test {
 
     #[test]
     fn supports() {
-        let codec = encoder::find(Id::VP9).expect("can find VP9 encoder");
+        let codec = encoder::find(Id::FFV1).expect("can find FFV1 encoder");
 
         assert!(supported_color_ranges(codec, None)
             .expect("can check color range support")
-            .supports(Range::JPEG));
+            .supports(Range::MPEG));
 
         assert!(!supported_pixel_formats(codec, None)
             .expect("can check color range support")
-            .supports(Pixel::BGR8));
+            .supports(Pixel::GRAY16));
 
         assert!(supported_frame_rates(codec, None)
             .expect("can check frame rate support")


### PR DESCRIPTION
Reasoning: See https://github.com/jrottenberg/ffmpeg/issues/410 and the PR linked there. TL;DR: An update to the docker images (which was done from a PR branch, not documented and can't be found anywhere on `main`) broke our CI & the one response I *have* gotten has not been reassuring.

Since the problem is effectively a showstopper for this repo, let's switch to something that shouldn't break so easily, even if it's a bit more work to set up initially.

Changes:

- Replace jrottenberg/ffmpeg docker container with prebuilt binaries from https://github.com/wang-bin/avbuild
  - This needs a bit of patching due to an [issue in the pkgconfig files](https://github.com/wang-bin/avbuild/issues/76)
  - otherwise, just extract to some directory and then set `PKG_CONFIG_PATH` for compile time and `LD_LIBRARY_PATH` for runtime
- Remove 5.0 and 6.0 from CI as they are [EOL](https://ffmpeg.org/olddownload.html) upstream
- Adjust a few tests that relied on the external libraries included in FFmpeg