### PR TITLE
Don't pass `AsRef<T>` params by reference

### DIFF
--- a/examples/chapters.rs
+++ b/examples/chapters.rs
@@ -5,7 +5,7 @@ use std::env;
 fn main() {
     ffmpeg::init().unwrap();
 
-    match ffmpeg::format::input(&env::args().nth(1).expect("missing input file name")) {
+    match ffmpeg::format::input(env::args().nth(1).expect("missing input file name")) {
         Ok(ictx) => {
             println!("Nb chapters: {}", ictx.nb_chapters());
 
@@ -20,7 +20,7 @@ fn main() {
                 }
             }
 
-            let mut octx = ffmpeg::format::output(&"test.mkv").expect("Couldn't open test file");
+            let mut octx = ffmpeg::format::output("test.mkv").expect("Couldn't open test file");
 
             for chapter in ictx.chapters() {
                 let title = match chapter.metadata().get("title") {

--- a/examples/dump-frames.rs
+++ b/examples/dump-frames.rs
@@ -11,7 +11,7 @@ use std::io::prelude::*;
 fn main() -> Result<(), ffmpeg::Error> {
     ffmpeg::init().unwrap();
 
-    if let Ok(mut ictx) = input(&env::args().nth(1).expect("Cannot open file.")) {
+    if let Ok(mut ictx) = input(env::args().nth(1).expect("Cannot open file.")) {
         let input = ictx
             .streams()
             .best(Type::Video)

--- a/examples/metadata.rs
+++ b/examples/metadata.rs
@@ -5,7 +5,7 @@ use std::env;
 fn main() -> Result<(), ffmpeg::Error> {
     ffmpeg::init().unwrap();
 
-    match ffmpeg::format::input(&env::args().nth(1).expect("missing file")) {
+    match ffmpeg::format::input(env::args().nth(1).expect("missing file")) {
         Ok(context) => {
             for (k, v) in context.metadata().iter() {
                 println!("{k}: {v}");

--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -72,7 +72,7 @@ struct Transcoder {
 fn transcoder<P: AsRef<Path>>(
     ictx: &mut format::context::Input,
     octx: &mut format::context::Output,
-    path: &P,
+    path: P,
     filter_spec: &str,
 ) -> Result<Transcoder, ffmpeg::Error> {
     let input = ictx

--- a/src/format/format/output.rs
+++ b/src/format/format/output.rs
@@ -57,7 +57,7 @@ impl Output {
         }
     }
 
-    pub fn codec<P: AsRef<Path>>(self, path: &P, kind: media::Type) -> codec::Id {
+    pub fn codec<P: AsRef<Path>>(self, path: P, kind: media::Type) -> codec::Id {
         // XXX: use to_cstring when stable
         let path = CString::new(path.as_ref().to_str().unwrap()).unwrap();
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -36,11 +36,11 @@ pub fn license() -> &'static str {
 }
 
 // XXX: use to_cstring when stable
-fn from_path<P: AsRef<Path>>(path: &P) -> CString {
+fn from_path<P: AsRef<Path>>(path: P) -> CString {
     CString::new(path.as_ref().as_os_str().to_str().unwrap()).unwrap()
 }
 
-pub fn input<P: AsRef<Path>>(path: &P) -> Result<context::Input, Error> {
+pub fn input<P: AsRef<Path>>(path: P) -> Result<context::Input, Error> {
     unsafe {
         let mut ps = ptr::null_mut();
         let path = from_path(path);
@@ -60,7 +60,7 @@ pub fn input<P: AsRef<Path>>(path: &P) -> Result<context::Input, Error> {
 }
 
 pub fn input_with_dictionary<P: AsRef<Path>>(
-    path: &P,
+    path: P,
     options: Dictionary,
 ) -> Result<context::Input, Error> {
     unsafe {
@@ -85,10 +85,7 @@ pub fn input_with_dictionary<P: AsRef<Path>>(
     }
 }
 
-pub fn input_with_interrupt<P: AsRef<Path>, F>(
-    path: &P,
-    closure: F,
-) -> Result<context::Input, Error>
+pub fn input_with_interrupt<P: AsRef<Path>, F>(path: P, closure: F) -> Result<context::Input, Error>
 where
     F: FnMut() -> bool,
 {
@@ -111,7 +108,7 @@ where
     }
 }
 
-pub fn output<P: AsRef<Path>>(path: &P) -> Result<context::Output, Error> {
+pub fn output<P: AsRef<Path>>(path: P) -> Result<context::Output, Error> {
     unsafe {
         let mut ps = ptr::null_mut();
         let path = from_path(path);
@@ -127,10 +124,7 @@ pub fn output<P: AsRef<Path>>(path: &P) -> Result<context::Output, Error> {
     }
 }
 
-pub fn output_with<P: AsRef<Path>>(
-    path: &P,
-    options: Dictionary,
-) -> Result<context::Output, Error> {
+pub fn output_with<P: AsRef<Path>>(path: P, options: Dictionary) -> Result<context::Output, Error> {
     unsafe {
         let mut ps = ptr::null_mut();
         let path = from_path(path);
@@ -159,7 +153,7 @@ pub fn output_with<P: AsRef<Path>>(
     }
 }
 
-pub fn output_as<P: AsRef<Path>>(path: &P, format: &str) -> Result<context::Output, Error> {
+pub fn output_as<P: AsRef<Path>>(path: P, format: &str) -> Result<context::Output, Error> {
     unsafe {
         let mut ps = ptr::null_mut();
         let path = from_path(path);
@@ -182,7 +176,7 @@ pub fn output_as<P: AsRef<Path>>(path: &P, format: &str) -> Result<context::Outp
 }
 
 pub fn output_as_with<P: AsRef<Path>>(
-    path: &P,
+    path: P,
     format: &str,
     options: Dictionary,
 ) -> Result<context::Output, Error> {


### PR DESCRIPTION
Doesn't really make sense to require a reference for these params, as both `String` and `&str` (etc.) implement `AsRef<Path>`.

This is breaking.