### PR TITLE
ci: Remove unnecessary pkgconfig patches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-                               libva2 libva-drm2 libva-x11-2 libvdpau1 libxv1
+                               libc++1 libva2 libva-drm2 libva-x11-2 libvdpau1 libxv1
       - name: Download FFmpeg
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,11 +64,6 @@ jobs:
           curl -L "https://sourceforge.net/projects/avbuild/files/linux/${{ matrix.ffmpeg.file }}/download" \
             | tar xJf - --strip 1 -C ffmpeg-libs
 
-          # https://github.com/wang-bin/avbuild/issues/76
-          PC_FILES=(ffmpeg-libs/lib/${{ matrix.ffmpeg.lib_subdir }}/pkgconfig/*.pc)
-          sed -i 's/^prefix=.*$/prefix=${pcfiledir}\/..\/..\/../g' $PC_FILES
-          sed -i 's/^libdir=.*$/libdir=${prefix}\/lib\/${{ matrix.ffmpeg.lib_subdir }}/g' $PC_FILES
-
           echo "PKG_CONFIG_PATH=$PWD/ffmpeg-libs/lib/${{ matrix.ffmpeg.lib_subdir }}/pkgconfig" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$PWD/ffmpeg-libs/lib/${{ matrix.ffmpeg.lib_subdir }}" >> "$GITHUB_ENV"
       - name: Install Rust stable with clippy and rustfmt
@@ -199,11 +194,6 @@ jobs:
           mkdir ffmpeg-libs
           curl -L "https://sourceforge.net/projects/avbuild/files/linux/ffmpeg-7.1-linux-clang-lite.tar.xz/download" \
             | tar xJf - --strip 1 -C ffmpeg-libs
-
-          # https://github.com/wang-bin/avbuild/issues/76
-          PC_FILES=(ffmpeg-libs/lib/amd64/pkgconfig/*.pc)
-          sed -i 's/^prefix=.*$/prefix=${pcfiledir}\/..\/..\/../g' $PC_FILES
-          sed -i 's/^libdir=.*$/libdir=${prefix}\/lib\/amd64/g' $PC_FILES
 
           echo "PKG_CONFIG_PATH=$PWD/ffmpeg-libs/lib/amd64/pkgconfig" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$PWD/ffmpeg-libs" >> "$GITHUB_ENV"


### PR DESCRIPTION
Followup to #83. In a [very nice move](https://github.com/wang-bin/avbuild/issues/76#issuecomment-2464584408), the older binary packages were updated to include fixes to the pkgconfig files from the start, making the patches unnecessary.