### PR TITLE
Refactor `codec::Parameters`

### DIFF
--- a/examples/remux.rs
+++ b/examples/remux.rs
@@ -35,7 +35,7 @@ fn main() {
         // issues when muxing into a different container format. Unfortunately
         // there's no high level API to do this (yet).
         unsafe {
-            (*ost.parameters().as_mut_ptr()).codec_tag = 0;
+            (*ost.parameters_mut().as_mut_ptr()).codec_tag = 0;
         }
     }
 

--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -135,7 +135,7 @@ fn transcoder<P: AsRef<Path>>(
     output.set_time_base((1, decoder.rate() as i32));
 
     let encoder = encoder.open_as(codec)?;
-    output.set_parameters(&encoder);
+    output.copy_parameters_from_context(&encoder);
 
     let filter = filter(filter_spec, &decoder, &encoder)?;
 

--- a/examples/transcode-x264.rs
+++ b/examples/transcode-x264.rs
@@ -70,7 +70,7 @@ impl Transcoder {
         encoder = codec::context::Context::from_parameters(ost.parameters())?
             .encoder()
             .video()?;
-        ost.set_parameters(&encoder);
+        ost.copy_parameters_from_context(&encoder);
         Ok(Self {
             ost_index,
             decoder,
@@ -224,7 +224,7 @@ fn main() {
             // issues when muxing into a different container format. Unfortunately
             // there's no high level API to do this (yet).
             unsafe {
-                (*ost.parameters().as_mut_ptr()).codec_tag = 0;
+                (*ost.parameters_mut().as_mut_ptr()).codec_tag = 0;
             }
         }
         ost_index += 1;

--- a/src/as_ptr.rs
+++ b/src/as_ptr.rs
@@ -1,0 +1,9 @@
+pub trait AsPtr<T> {
+    /// Returns a *const raw pointer to the underlying FFmpeg type.
+    fn as_ptr(&self) -> *const T;
+}
+
+pub trait AsMutPtr<T> {
+    /// Returns a *mut raw pointer to the underlying FFmpeg type.
+    fn as_mut_ptr(&mut self) -> *mut T;
+}

--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -4,9 +4,10 @@ use std::rc::Rc;
 
 use super::decoder::Decoder;
 use super::encoder::Encoder;
-use super::{threading, Compliance, Debug, Flags, Id, Parameters};
+use super::{threading, Compliance, Debug, Flags, Id};
 use crate::ffi::*;
 use crate::media;
+use crate::AsPtr;
 use crate::{Codec, Error};
 use libc::c_int;
 
@@ -41,8 +42,7 @@ impl Context {
         }
     }
 
-    pub fn from_parameters<P: Into<Parameters>>(parameters: P) -> Result<Self, Error> {
-        let parameters = parameters.into();
+    pub fn from_parameters<P: AsPtr<AVCodecParameters>>(parameters: P) -> Result<Self, Error> {
         let mut context = Self::new();
 
         unsafe {
@@ -113,9 +113,10 @@ impl Context {
         }
     }
 
-    pub fn set_parameters<P: Into<Parameters>>(&mut self, parameters: P) -> Result<(), Error> {
-        let parameters = parameters.into();
-
+    pub fn set_parameters<P: AsPtr<AVCodecParameters>>(
+        &mut self,
+        parameters: P,
+    ) -> Result<(), Error> {
         unsafe {
             match avcodec_parameters_to_context(self.as_mut_ptr(), parameters.as_ptr()) {
                 e if e < 0 => Err(Error::from(e)),

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -28,7 +28,7 @@ pub mod codec;
 pub use self::codec::{Audio, Codec, Video};
 
 pub mod parameters;
-pub use self::parameters::Parameters;
+pub use self::parameters::{Parameters, ParametersMut, ParametersRef};
 
 pub mod audio_service;
 pub mod field_order;

--- a/src/codec/parameters/borrowed.rs
+++ b/src/codec/parameters/borrowed.rs
@@ -1,0 +1,34 @@
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+use crate::codec::Id;
+use crate::ffi::*;
+use crate::media;
+
+pub struct ParametersRef<'p> {
+    ptr: NonNull<AVCodecParameters>,
+    _marker: PhantomData<&'p AVCodecParameters>,
+}
+
+impl<'p> ParametersRef<'p> {
+    pub unsafe fn from_raw(ptr: *const AVCodecParameters) -> Option<Self> {
+        NonNull::new(ptr as *mut _).map(|ptr| Self {
+            ptr,
+            _marker: PhantomData,
+        })
+    }
+
+    pub fn as_ptr(&self) -> *const AVCodecParameters {
+        self.ptr.as_ptr()
+    }
+}
+
+impl<'p> ParametersRef<'p> {
+    pub fn medium(&self) -> media::Type {
+        unsafe { media::Type::from((*self.as_ptr()).codec_type) }
+    }
+
+    pub fn id(&self) -> Id {
+        unsafe { Id::from((*self.as_ptr()).codec_id) }
+    }
+}

--- a/src/codec/parameters/borrowed.rs
+++ b/src/codec/parameters/borrowed.rs
@@ -10,6 +10,12 @@ pub struct ParametersRef<'p> {
 }
 
 impl<'p> ParametersRef<'p> {
+    /// # Safety
+    ///
+    /// Ensure that
+    /// - `ptr` is either null or valid,
+    /// - the shared borrow represented by `ptr` follows Rust borrow rules and
+    /// - the lifetime of the returned struct is correctly bounded.
     pub unsafe fn from_raw(ptr: *const AVCodecParameters) -> Option<Self> {
         NonNull::new(ptr as *mut _).map(|ptr| Self {
             ptr,
@@ -17,6 +23,9 @@ impl<'p> ParametersRef<'p> {
         })
     }
 
+    /// Exposes a pointer to the contained [`AVCodecParameters`] for FFI purposes.
+    ///
+    /// This is guaranteed to be a non-null pointer.
     pub fn as_ptr(&self) -> *const AVCodecParameters {
         self.ptr.as_ptr()
     }

--- a/src/codec/parameters/borrowed.rs
+++ b/src/codec/parameters/borrowed.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 use std::ptr::NonNull;
 
 use crate::ffi::*;
+use crate::AsPtr;
 
 pub struct ParametersRef<'p> {
     ptr: NonNull<AVCodecParameters>,
@@ -17,6 +18,12 @@ impl<'p> ParametersRef<'p> {
     }
 
     pub fn as_ptr(&self) -> *const AVCodecParameters {
+        self.ptr.as_ptr()
+    }
+}
+
+impl<'p> AsPtr<AVCodecParameters> for ParametersRef<'p> {
+    fn as_ptr(&self) -> *const AVCodecParameters {
         self.ptr.as_ptr()
     }
 }

--- a/src/codec/parameters/borrowed.rs
+++ b/src/codec/parameters/borrowed.rs
@@ -1,9 +1,7 @@
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 
-use crate::codec::Id;
 use crate::ffi::*;
-use crate::media;
 
 pub struct ParametersRef<'p> {
     ptr: NonNull<AVCodecParameters>,
@@ -20,15 +18,5 @@ impl<'p> ParametersRef<'p> {
 
     pub fn as_ptr(&self) -> *const AVCodecParameters {
         self.ptr.as_ptr()
-    }
-}
-
-impl<'p> ParametersRef<'p> {
-    pub fn medium(&self) -> media::Type {
-        unsafe { media::Type::from((*self.as_ptr()).codec_type) }
-    }
-
-    pub fn id(&self) -> Id {
-        unsafe { Id::from((*self.as_ptr()).codec_id) }
     }
 }

--- a/src/codec/parameters/borrowed_mut.rs
+++ b/src/codec/parameters/borrowed_mut.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 use std::ptr::NonNull;
 
 use crate::ffi::*;
+use crate::{AsMutPtr, AsPtr};
 
 pub struct ParametersMut<'p> {
     ptr: NonNull<AVCodecParameters>,
@@ -22,5 +23,17 @@ impl<'p> ParametersMut<'p> {
 
     pub fn as_mut_ptr(&mut self) -> *mut AVCodecParameters {
         self.ptr.as_ptr()
+    }
+}
+
+impl<'p> AsPtr<AVCodecParameters> for ParametersMut<'p> {
+    fn as_ptr(&self) -> *const AVCodecParameters {
+        self.as_ptr()
+    }
+}
+
+impl<'p> AsMutPtr<AVCodecParameters> for ParametersMut<'p> {
+    fn as_mut_ptr(&mut self) -> *mut AVCodecParameters {
+        self.as_mut_ptr()
     }
 }

--- a/src/codec/parameters/borrowed_mut.rs
+++ b/src/codec/parameters/borrowed_mut.rs
@@ -1,9 +1,7 @@
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 
-use crate::codec::Id;
 use crate::ffi::*;
-use crate::media;
 
 pub struct ParametersMut<'p> {
     ptr: NonNull<AVCodecParameters>,
@@ -24,15 +22,5 @@ impl<'p> ParametersMut<'p> {
 
     pub fn as_mut_ptr(&mut self) -> *mut AVCodecParameters {
         self.ptr.as_ptr()
-    }
-}
-
-impl<'p> ParametersMut<'p> {
-    pub fn medium(&self) -> media::Type {
-        unsafe { media::Type::from((*self.as_ptr()).codec_type) }
-    }
-
-    pub fn id(&self) -> Id {
-        unsafe { Id::from((*self.as_ptr()).codec_id) }
     }
 }

--- a/src/codec/parameters/borrowed_mut.rs
+++ b/src/codec/parameters/borrowed_mut.rs
@@ -1,0 +1,38 @@
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+use crate::codec::Id;
+use crate::ffi::*;
+use crate::media;
+
+pub struct ParametersMut<'p> {
+    ptr: NonNull<AVCodecParameters>,
+    _marker: PhantomData<&'p mut AVCodecParameters>,
+}
+
+impl<'p> ParametersMut<'p> {
+    pub unsafe fn from_raw(ptr: *mut AVCodecParameters) -> Option<Self> {
+        NonNull::new(ptr as *mut _).map(|ptr| Self {
+            ptr,
+            _marker: PhantomData,
+        })
+    }
+
+    pub fn as_ptr(&self) -> *const AVCodecParameters {
+        self.ptr.as_ptr()
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut AVCodecParameters {
+        self.ptr.as_ptr()
+    }
+}
+
+impl<'p> ParametersMut<'p> {
+    pub fn medium(&self) -> media::Type {
+        unsafe { media::Type::from((*self.as_ptr()).codec_type) }
+    }
+
+    pub fn id(&self) -> Id {
+        unsafe { Id::from((*self.as_ptr()).codec_id) }
+    }
+}

--- a/src/codec/parameters/borrowed_mut.rs
+++ b/src/codec/parameters/borrowed_mut.rs
@@ -10,6 +10,12 @@ pub struct ParametersMut<'p> {
 }
 
 impl<'p> ParametersMut<'p> {
+    /// # Safety
+    ///
+    /// Ensure that
+    /// - `ptr` is either null or valid,
+    /// - the mutable borrow represented by `ptr` follows Rust borrow rules and
+    /// - the lifetime of the returned struct is correctly bounded.
     pub unsafe fn from_raw(ptr: *mut AVCodecParameters) -> Option<Self> {
         NonNull::new(ptr as *mut _).map(|ptr| Self {
             ptr,
@@ -17,10 +23,16 @@ impl<'p> ParametersMut<'p> {
         })
     }
 
+    /// Exposes a pointer to the contained [`AVCodecParameters`] for FFI purposes.
+    ///
+    /// This is guaranteed to be a non-null pointer.
     pub fn as_ptr(&self) -> *const AVCodecParameters {
         self.ptr.as_ptr()
     }
 
+    /// Exposes a mutable pointer to the contained [`AVCodecParameters`] for FFI purposes.
+    ///
+    /// This is guaranteed to be a non-null pointer.
     pub fn as_mut_ptr(&mut self) -> *mut AVCodecParameters {
         self.ptr.as_ptr()
     }

--- a/src/codec/parameters/common.rs
+++ b/src/codec/parameters/common.rs
@@ -1,0 +1,17 @@
+use crate::macros::impl_for_many;
+
+use super::{Parameters, ParametersMut, ParametersRef};
+use crate::codec::Id;
+use crate::media;
+
+impl_for_many! {
+    impl for Parameters, ParametersRef<'p>, ParametersMut<'p> {
+        pub fn medium(&self) -> media::Type {
+            unsafe { (*self.as_ptr()).codec_type.into() }
+        }
+
+        pub fn id(&self) -> Id {
+            unsafe { (*self.as_ptr()).codec_id.into() }
+        }
+    }
+}

--- a/src/codec/parameters/common.rs
+++ b/src/codec/parameters/common.rs
@@ -1,8 +1,14 @@
 use crate::macros::impl_for_many;
 
 use super::{Parameters, ParametersMut, ParametersRef};
+use crate::chroma::Location;
 use crate::codec::Id;
+use crate::color;
 use crate::media;
+use crate::{FieldOrder, Rational};
+
+#[cfg(feature = "ffmpeg_5_1")]
+use crate::ChannelLayout;
 
 impl_for_many! {
     impl for Parameters, ParametersRef<'p>, ParametersMut<'p> {
@@ -12,6 +18,123 @@ impl_for_many! {
 
         pub fn id(&self) -> Id {
             unsafe { (*self.as_ptr()).codec_id.into() }
+        }
+
+        // TODO: codec_tag
+        // TODO: extradata
+        // TODO: coded_side_data
+        // TODO: format (needs From<c_int> for format::Pixel and format::Sample)
+
+        pub fn bit_rate(&self) -> i64 {
+            unsafe { (*self.as_ptr()).bit_rate }
+        }
+
+        pub fn bits_per_coded_sample(&self) -> u32 {
+            unsafe { (*self.as_ptr()).bits_per_coded_sample as u32 }
+        }
+
+        pub fn bits_per_raw_sample(&self) -> u32 {
+            unsafe { (*self.as_ptr()).bits_per_raw_sample as u32 }
+        }
+
+        pub fn profile(&self) -> i32 {
+            unsafe { (*self.as_ptr()).profile as i32 }
+        }
+
+        pub fn level(&self) -> i32 {
+            unsafe { (*self.as_ptr()).level as i32 }
+        }
+
+        /// Video only
+        pub fn width(&self) -> u32 {
+            unsafe { (*self.as_ptr()).width as u32 }
+        }
+
+        /// Video only
+        pub fn height(&self) -> u32 {
+            unsafe { (*self.as_ptr()).height as u32 }
+        }
+
+        /// Video only
+        pub fn sample_aspect_ratio(&self) -> Rational {
+            unsafe { (*self.as_ptr()).sample_aspect_ratio.into() }
+        }
+
+        /// Video only
+        #[cfg(feature = "ffmpeg_6_1")]
+        pub fn framerate(&self) -> Rational {
+            unsafe { (*self.as_ptr()).framerate.into() }
+        }
+
+        /// Video only
+        pub fn field_order(&self) -> FieldOrder {
+            unsafe { (*self.as_ptr()).field_order.into() }
+        }
+
+        /// Video only
+        pub fn color_range(&self) -> color::Range {
+            unsafe { (*self.as_ptr()).color_range.into() }
+        }
+
+        /// Video only
+        pub fn color_primaries(&self) -> color::Primaries {
+            unsafe { (*self.as_ptr()).color_primaries.into() }
+        }
+
+        /// Video only
+        pub fn color_transfer_characteristic(&self) -> color::TransferCharacteristic {
+            unsafe { (*self.as_ptr()).color_trc.into() }
+        }
+
+        /// Video only
+        pub fn color_space(&self) -> color::Space {
+            unsafe { (*self.as_ptr()).color_space.into() }
+        }
+
+        /// Video only
+        pub fn chroma_location(&self) -> Location {
+            unsafe { (*self.as_ptr()).chroma_location.into() }
+        }
+
+        /// Video only
+        pub fn video_delay(&self) -> i32 {
+            unsafe { (*self.as_ptr()).video_delay as i32 }
+        }
+
+        /// Audio only
+        #[cfg(feature = "ffmpeg_5_1")]
+        pub fn ch_layout(&self) -> ChannelLayout {
+            unsafe { ChannelLayout::from(&(*self.as_ptr()).ch_layout) }
+        }
+
+        /// Audio only
+        pub fn sample_rate(&self) -> u32 {
+            unsafe { (*self.as_ptr()).sample_rate as u32 }
+        }
+
+        /// Audio only
+        pub fn block_align(&self) -> u32 {
+            unsafe { (*self.as_ptr()).block_align as u32 }
+        }
+
+        /// Audio only
+        pub fn frame_size(&self) -> u32 {
+            unsafe { (*self.as_ptr()).frame_size as u32 }
+        }
+
+        /// Audio only
+        pub fn initial_padding(&self) -> u32 {
+            unsafe { (*self.as_ptr()).initial_padding as u32 }
+        }
+
+        /// Audio only
+        pub fn trailing_padding(&self) -> u32 {
+            unsafe { (*self.as_ptr()).trailing_padding as u32 }
+        }
+
+        /// Audio only
+        pub fn seek_preroll(&self) -> u32 {
+            unsafe { (*self.as_ptr()).seek_preroll as u32 }
         }
     }
 }

--- a/src/codec/parameters/mod.rs
+++ b/src/codec/parameters/mod.rs
@@ -1,0 +1,7 @@
+mod borrowed;
+mod borrowed_mut;
+mod owned;
+
+pub use borrowed::ParametersRef;
+pub use borrowed_mut::ParametersMut;
+pub use owned::Parameters;

--- a/src/codec/parameters/mod.rs
+++ b/src/codec/parameters/mod.rs
@@ -1,5 +1,6 @@
 mod borrowed;
 mod borrowed_mut;
+mod common;
 mod owned;
 
 pub use borrowed::ParametersRef;

--- a/src/codec/parameters/owned.rs
+++ b/src/codec/parameters/owned.rs
@@ -1,8 +1,7 @@
 use std::ptr::NonNull;
 
-use crate::codec::{Context, Id};
+use crate::codec::Context;
 use crate::ffi::*;
-use crate::media;
 
 pub struct Parameters {
     ptr: NonNull<AVCodecParameters>,
@@ -31,14 +30,6 @@ impl Parameters {
         Self {
             ptr: NonNull::new(ptr).expect("can allocate AVCodecParameters"),
         }
-    }
-
-    pub fn medium(&self) -> media::Type {
-        unsafe { media::Type::from((*self.as_ptr()).codec_type) }
-    }
-
-    pub fn id(&self) -> Id {
-        unsafe { Id::from((*self.as_ptr()).codec_id) }
     }
 }
 

--- a/src/codec/parameters/owned.rs
+++ b/src/codec/parameters/owned.rs
@@ -2,6 +2,7 @@ use std::ptr::NonNull;
 
 use crate::codec::Context;
 use crate::ffi::*;
+use crate::{AsMutPtr, AsPtr};
 
 pub struct Parameters {
     ptr: NonNull<AVCodecParameters>,
@@ -59,6 +60,18 @@ impl Clone for Parameters {
         unsafe {
             avcodec_parameters_copy(self.as_mut_ptr(), source.as_ptr());
         }
+    }
+}
+
+impl AsPtr<AVCodecParameters> for Parameters {
+    fn as_ptr(&self) -> *const AVCodecParameters {
+        self.as_ptr()
+    }
+}
+
+impl AsMutPtr<AVCodecParameters> for Parameters {
+    fn as_mut_ptr(&mut self) -> *mut AVCodecParameters {
+        self.as_mut_ptr()
     }
 }
 

--- a/src/codec/parameters/owned.rs
+++ b/src/codec/parameters/owned.rs
@@ -11,20 +11,33 @@ pub struct Parameters {
 unsafe impl Send for Parameters {}
 
 impl Parameters {
+    /// # Safety
+    ///
+    /// Ensure that
+    /// - it is valid for the returned struct to take ownership of the [`AVCodecParameters`]
+    ///   and that
+    /// - `ptr` is not used to break Rust's ownership rules after calling this function.
     pub unsafe fn from_raw(ptr: *mut AVCodecParameters) -> Option<Self> {
         NonNull::new(ptr).map(|ptr| Self { ptr })
     }
 
+    /// Exposes a pointer to the contained [`AVCodecParameters`] for FFI purposes.
+    ///
+    /// This is guaranteed to be a non-null pointer.
     pub fn as_ptr(&self) -> *const AVCodecParameters {
         self.ptr.as_ptr()
     }
 
+    /// Exposes a mutable pointer to the contained [`AVCodecParameters`] for FFI purposes.
+    ///
+    /// This is guaranteed to be a non-null pointer.
     pub fn as_mut_ptr(&mut self) -> *mut AVCodecParameters {
         self.ptr.as_ptr()
     }
 }
 
 impl Parameters {
+    /// Allocates a new set of codec parameters set to default values.
     pub fn new() -> Self {
         let ptr = unsafe { avcodec_parameters_alloc() };
 

--- a/src/format/stream/stream.rs
+++ b/src/format/stream/stream.rs
@@ -31,9 +31,9 @@ impl<'a> Stream<'a> {
         unsafe { codec::Context::wrap((*self.as_ptr()).codec, Some(self.context.destructor())) }
     }
 
-    pub fn parameters(&self) -> codec::Parameters {
+    pub fn parameters(&self) -> codec::ParametersRef {
         unsafe {
-            codec::Parameters::wrap((*self.as_ptr()).codecpar, Some(self.context.destructor()))
+            codec::ParametersRef::from_raw((*self.as_ptr()).codecpar).expect("codecpar is non-null")
         }
     }
 

--- a/src/format/stream/stream_mut.rs
+++ b/src/format/stream/stream_mut.rs
@@ -5,7 +5,7 @@ use super::Stream;
 use crate::ffi::*;
 use crate::format::context::common::Context;
 use crate::AsPtr;
-use crate::{Dictionary, Rational};
+use crate::{codec, Dictionary, Rational};
 
 pub struct StreamMut<'a> {
     context: &'a mut Context,
@@ -48,9 +48,22 @@ impl<'a> StreamMut<'a> {
         }
     }
 
+    pub fn parameters_mut(&mut self) -> codec::ParametersMut {
+        unsafe {
+            codec::ParametersMut::from_raw((*self.as_mut_ptr()).codecpar)
+                .expect("codecpar is non-null")
+        }
+    }
+
     pub fn set_parameters<P: AsPtr<AVCodecParameters>>(&mut self, parameters: P) {
         unsafe {
             avcodec_parameters_copy((*self.as_mut_ptr()).codecpar, parameters.as_ptr());
+        }
+    }
+
+    pub fn copy_parameters_from_context(&mut self, ctx: &codec::Context) {
+        unsafe {
+            avcodec_parameters_from_context((*self.as_mut_ptr()).codecpar, ctx.as_ptr());
         }
     }
 

--- a/src/format/stream/stream_mut.rs
+++ b/src/format/stream/stream_mut.rs
@@ -4,7 +4,8 @@ use std::ops::Deref;
 use super::Stream;
 use crate::ffi::*;
 use crate::format::context::common::Context;
-use crate::{codec, Dictionary, Rational};
+use crate::AsPtr;
+use crate::{Dictionary, Rational};
 
 pub struct StreamMut<'a> {
     context: &'a mut Context,
@@ -47,9 +48,7 @@ impl<'a> StreamMut<'a> {
         }
     }
 
-    pub fn set_parameters<P: Into<codec::Parameters>>(&mut self, parameters: P) {
-        let parameters = parameters.into();
-
+    pub fn set_parameters<P: AsPtr<AVCodecParameters>>(&mut self, parameters: P) {
         unsafe {
             avcodec_parameters_copy((*self.as_mut_ptr()).codecpar, parameters.as_ptr());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,9 @@ pub use crate::filter::Filter;
 
 pub mod software;
 
+mod as_ptr;
+pub use as_ptr::{AsMutPtr, AsPtr};
+
 pub(crate) mod macros;
 pub(crate) mod utils;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub use crate::filter::Filter;
 
 pub mod software;
 
+pub(crate) mod macros;
 pub(crate) mod utils;
 
 fn init_error() {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,37 @@
+macro_rules! impl_for_one {
+    // ref/mut with lifetime
+    ($wrapper:ident, $lt:lifetime, $func:item) => {
+        impl<$lt> $wrapper<$lt> {
+            $func
+        }
+    };
+    // owned without lifetime
+    ($wrapper:ident, $func:item) => {
+        impl $wrapper {
+            $func
+        }
+    };
+}
+
+macro_rules! impl_for_many {
+    { impl for $($wrapper:ident$(<$lt:lifetime>)?),+ {} } => {};
+    {
+        impl for $($wrapper:ident$(<$lt:lifetime>)?),+ {
+            $func:item
+            $($tt:tt)*
+        }
+    } => {
+        $(
+            $crate::macros::impl_for_one!($wrapper$(, $lt)?, $func);
+        )+
+
+        impl_for_many!{
+            impl for $($wrapper$(<$lt>)?),+ {
+                $($tt)*
+            }
+        }
+    };
+}
+
+pub(crate) use impl_for_many;
+pub(crate) use impl_for_one;


### PR DESCRIPTION
Currently, `Parameters` tries to differentiate its states (owned, shared) by setting the `owner` field. With the way the API works at the moment, there really isn't any advantage to this over using different structs for owned, shared, and mutable shared states. It takes up an extra `Rc` and complicates the differentiation between immutable and mutable borrows (since it's all the same type).

I'm also pretty sure that there is some potential for nasty UB via `Stream::parameters` because the returned `Parameters` type can be accessed mutably[^1] even though `Stream` is supposed to be an immutable reference to `AVStream`.

Some notes regarding the new implementation:
- I want to use the pattern `Something` (owned), `SomethingRef`, `SomethingMut` for other wrapper types in the future
- I don't want to use `impl<'a> AsRef<SomethingRef<'a>> for Something` because it returns a `&'b SomethingRef<'a>` with two levels of indirection, which seems unnecessary
- The macros are required to keep the boilerplate under control. I might even want to add more macros to implement common field types and/or traits with less code
- I might add safety docs to `from_raw`. At the moment, the only safety concern is that you need to bound the returned lifetime correctly (since it can otherwise be arbitrarily chosen). The best way to do this is by bounding it on a borrow of another type:
  ```rs
  pub fn something<'s>(&'s self) -> SomethingRef<'s> { /* ... */ }
  ```
- `StreamMut::copy_parameters_from_context` seems a bit unnecessary, but it is more efficient. The old implementation always allocated a new `AVCodecParameters` from a context, and then copied that `AVCodecParameters` into the stream. The new one just uses `parameters_from_context(stream.codecpar, context)` which avoids the in-between step

[^1]: See examples/transcode-x264.rs: `(*ost.parameters().as_mut_ptr()).codec_tag = 0;`