### PR TITLE
Fix clippy `needless_lifetimes` lint

### DIFF
--- a/src/codec/traits.rs
+++ b/src/codec/traits.rs
@@ -7,7 +7,7 @@ pub trait Decoder<T> {
     fn decoder(self) -> Option<Codec<T>>;
 }
 
-impl<'a> Decoder<UnknownType> for &'a str {
+impl Decoder<UnknownType> for &str {
     fn decoder(self) -> Option<Codec<UnknownType>> {
         decoder::find_by_name(self)
     }
@@ -39,7 +39,7 @@ pub trait Encoder<T> {
     fn encoder(self) -> Option<Codec<T>>;
 }
 
-impl<'a> Encoder<UnknownType> for &'a str {
+impl Encoder<UnknownType> for &str {
     fn encoder(self) -> Option<Codec<UnknownType>> {
         encoder::find_by_name(self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 #![allow(clippy::too_many_arguments)]
 // FFI Types may differ across platforms, making casts necessary
 #![allow(clippy::unnecessary_cast)]
+// This lint sometimes suggests worse code. See rust-lang/rust-clippy#13514
+#![allow(clippy::needless_lifetimes)]
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
`needless_lifetimes` seems to have been stabilized in 1.83. It correctly identifies completely unnecessary lifetimes, but also warns on cases like this:

```rs
warning: the following explicit lifetimes could be elided: 'a
  --> src/software/scaling/vector.rs:32:6
   |
32 | impl<'a> Vector<'a> {
   |      ^^         ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
32 - impl<'a> Vector<'a> {
32 + impl Vector<'_> {
```

I don't think this is an improvement, so unless https://github.com/rust-lang/rust-clippy/issues/13514 or something similar is done, I'd just `#![allow]` it.