### PR TITLE
Miscellaneous code modernizations

### DIFF
--- a/examples/chapters.rs
+++ b/examples/chapters.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_the_third as ffmpeg;
+use ffmpeg_the_third as ffmpeg;
 
 use std::env;
 

--- a/examples/codec-info.rs
+++ b/examples/codec-info.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_the_third as ffmpeg;
+use ffmpeg_the_third as ffmpeg;
 
 use std::env;
 

--- a/examples/dump-frames.rs
+++ b/examples/dump-frames.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_the_third as ffmpeg;
+use ffmpeg_the_third as ffmpeg;
 
 use crate::ffmpeg::format::{input, Pixel};
 use crate::ffmpeg::media::Type;

--- a/examples/metadata.rs
+++ b/examples/metadata.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_the_third as ffmpeg;
+use ffmpeg_the_third as ffmpeg;
 
 use std::env;
 

--- a/examples/remux.rs
+++ b/examples/remux.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_the_third as ffmpeg;
+use ffmpeg_the_third as ffmpeg;
 
 use std::env;
 

--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_the_third as ffmpeg;
+use ffmpeg_the_third as ffmpeg;
 
 use std::env;
 use std::path::Path;

--- a/examples/transcode-x264.rs
+++ b/examples/transcode-x264.rs
@@ -15,7 +15,7 @@
 //   transcode-x264 input.flv output.mp4
 //   transcode-x264 input.mkv output.mkv 'preset=veryslow,crf=18'
 
-extern crate ffmpeg_the_third as ffmpeg;
+use ffmpeg_the_third as ffmpeg;
 
 use std::collections::HashMap;
 use std::env;

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -629,7 +629,7 @@ fn rustc_link_extralibs(source_dir: &Path) {
         .map(|line| line.unwrap())
         .unwrap();
 
-    let linker_args = extra_libs.split('=').last().unwrap().split(' ');
+    let linker_args = extra_libs.split('=').next_back().unwrap().split(' ');
     let include_libs = linker_args
         .filter(|v| v.starts_with("-l"))
         .map(|flag| &flag[2..]);

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -1,8 +1,3 @@
-extern crate bindgen;
-extern crate cc;
-extern crate clang;
-extern crate pkg_config;
-
 use std::collections::HashMap;
 use std::env;
 use std::fmt::Write as FmtWrite;

--- a/ffmpeg-sys-the-third/src/avutil/pixfmt.rs
+++ b/ffmpeg-sys-the-third/src/avutil/pixfmt.rs
@@ -1,7 +1,7 @@
 use libc::c_int;
 
-use crate::{AVChromaLocation, AVPixelFormat};
 use crate::AVPixelFormat::*;
+use crate::{AVChromaLocation, AVPixelFormat};
 
 impl AVChromaLocation {
     pub fn from_c_int(n: c_int) -> Option<Self> {

--- a/ffmpeg-sys-the-third/src/lib.rs
+++ b/ffmpeg-sys-the-third/src/lib.rs
@@ -7,8 +7,6 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
 
-extern crate libc;
-
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 mod avutil;

--- a/src/codec/capabilities.rs
+++ b/src/codec/capabilities.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_uint;
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, Eq, PartialEq)]
     pub struct Capabilities: c_uint {
         const DRAW_HORIZ_BAND     = AV_CODEC_CAP_DRAW_HORIZ_BAND;

--- a/src/codec/debug.rs
+++ b/src/codec/debug.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     pub struct Debug: c_int {
         const PICT_INFO   = FF_DEBUG_PICT_INFO;
         const RC          = FF_DEBUG_RC;

--- a/src/codec/decoder/check.rs
+++ b/src/codec/decoder/check.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     pub struct Check: c_int {
         const CRC      = AV_EF_CRCCHECK;
         const BITSTREAM = AV_EF_BITSTREAM;

--- a/src/codec/decoder/conceal.rs
+++ b/src/codec/decoder/conceal.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     pub struct Conceal: c_int {
         const GUESS_MVS   = FF_EC_GUESS_MVS;
         const DEBLOCK     = FF_EC_DEBLOCK;

--- a/src/codec/decoder/slice.rs
+++ b/src/codec/decoder/slice.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     pub struct Flags: c_int {
         const CODED_ORDER = SLICE_FLAG_CODED_ORDER;
         const ALLOW_FIELD = SLICE_FLAG_ALLOW_FIELD;

--- a/src/codec/flag.rs
+++ b/src/codec/flag.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_uint;
 
-bitflags! {
+bitflags::bitflags! {
     pub struct Flags: c_uint {
         const UNALIGNED       = AV_CODEC_FLAG_UNALIGNED;
         const QSCALE          = AV_CODEC_FLAG_QSCALE;

--- a/src/codec/packet/flag.rs
+++ b/src/codec/packet/flag.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     pub struct Flags: c_int {
         const KEY     = AV_PKT_FLAG_KEY;
         const CORRUPT = AV_PKT_FLAG_CORRUPT;

--- a/src/codec/props.rs
+++ b/src/codec/props.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, Eq, PartialEq)]
     pub struct CodecProperties: c_int {
         const INTRA_ONLY = AV_CODEC_PROP_INTRA_ONLY;

--- a/src/codec/subtitle/flag.rs
+++ b/src/codec/subtitle/flag.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     pub struct Flags: c_int {
         const FORCED = AV_SUBTITLE_FLAG_FORCED;
     }

--- a/src/filter/flag.rs
+++ b/src/filter/flag.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     pub struct Flags: c_int {
         const DYNAMIC_INPUTS            = AVFILTER_FLAG_DYNAMIC_INPUTS;
         const DYNAMIC_OUTPUTS           = AVFILTER_FLAG_DYNAMIC_OUTPUTS;

--- a/src/format/format/flag.rs
+++ b/src/format/format/flag.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     pub struct Flags: c_int {
         const NO_FILE       = AVFMT_NOFILE;
         const NEED_NUMBER   = AVFMT_NEEDNUMBER;

--- a/src/format/stream/disposition.rs
+++ b/src/format/stream/disposition.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, Eq, PartialEq)]
     pub struct Disposition: c_int {
         const DEFAULT          = AV_DISPOSITION_DEFAULT;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::module_inception)]
-#![allow(clippy::too_many_arguments)]
 // FFI Types may differ across platforms, making casts necessary
 #![allow(clippy::unnecessary_cast)]
 // This lint sometimes suggests worse code. See rust-lang/rust-clippy#13514

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@
 // This lint sometimes suggests worse code. See rust-lang/rust-clippy#13514
 #![allow(clippy::needless_lifetimes)]
 
-#[macro_use]
-extern crate bitflags;
 pub extern crate ffmpeg_sys_the_third as sys;
 #[cfg(feature = "image")]
 extern crate image;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 pub use ffmpeg_sys_the_third as sys;
 pub use ffmpeg_sys_the_third as ffi;
 
-#[macro_use]
 pub mod util;
 pub use crate::util::channel_layout::{self, ChannelLayoutMask};
 #[cfg(feature = "ffmpeg_5_1")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,8 @@
 // This lint sometimes suggests worse code. See rust-lang/rust-clippy#13514
 #![allow(clippy::needless_lifetimes)]
 
-pub extern crate ffmpeg_sys_the_third as sys;
-#[cfg(feature = "image")]
-extern crate image;
-extern crate libc;
-#[cfg(feature = "serialize")]
-extern crate serde;
-
-pub use crate::sys as ffi;
+pub use ffmpeg_sys_the_third as sys;
+pub use ffmpeg_sys_the_third as ffi;
 
 #[macro_use]
 pub mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,54 +11,49 @@ pub use ffmpeg_sys_the_third as sys;
 pub use ffmpeg_sys_the_third as ffi;
 
 pub mod util;
-pub use crate::util::channel_layout::{self, ChannelLayoutMask};
 #[cfg(feature = "ffmpeg_5_1")]
 pub use crate::util::channel_layout::{
     Channel, ChannelCustom, ChannelLayout, ChannelLayoutIter, ChannelOrder,
 };
-pub use crate::util::chroma;
-pub use crate::util::color;
-pub use crate::util::dictionary;
-pub use crate::util::dictionary::Mut as DictionaryMut;
-pub use crate::util::dictionary::Owned as Dictionary;
-pub use crate::util::dictionary::Ref as DictionaryRef;
-pub use crate::util::error::{self, Error};
-pub use crate::util::frame::{self, Frame};
-pub use crate::util::log;
-pub use crate::util::mathematics::{self, rescale, Rescale, Rounding};
-pub use crate::util::media;
-pub use crate::util::option;
-pub use crate::util::picture;
-pub use crate::util::rational::{self, Rational};
-pub use crate::util::time;
+pub use crate::util::{
+    channel_layout::{self, ChannelLayoutMask},
+    chroma, color, dictionary,
+    dictionary::Mut as DictionaryMut,
+    dictionary::Owned as Dictionary,
+    dictionary::Ref as DictionaryRef,
+    error::{self, Error},
+    frame::{self, Frame},
+    log,
+    mathematics::{self, rescale, Rescale, Rounding},
+    media, option, picture,
+    rational::{self, Rational},
+    time,
+};
 
 #[cfg(feature = "format")]
 pub mod format;
 #[cfg(feature = "format")]
-pub use crate::format::chapter::{Chapter, ChapterMut};
-#[cfg(feature = "format")]
-pub use crate::format::stream::{Stream, StreamMut};
+pub use crate::format::{
+    chapter::{Chapter, ChapterMut},
+    stream::{Stream, StreamMut},
+};
 
 #[cfg(feature = "codec")]
 pub mod codec;
-#[cfg(feature = "codec")]
-pub use crate::codec::audio_service::AudioService;
-#[cfg(feature = "codec")]
-pub use crate::codec::codec::Codec;
-#[cfg(feature = "codec")]
-pub use crate::codec::discard::Discard;
-#[cfg(feature = "codec")]
-pub use crate::codec::field_order::FieldOrder;
-#[cfg(feature = "codec")]
-pub use crate::codec::packet::{self, Packet};
 #[cfg(all(feature = "codec", not(feature = "ffmpeg_5_0")))]
 pub use crate::codec::picture::Picture;
 #[cfg(feature = "codec")]
-pub use crate::codec::subtitle::{self, Subtitle};
-#[cfg(feature = "codec")]
-pub use crate::codec::threading;
-#[cfg(feature = "codec")]
-pub use crate::codec::{decoder, encoder};
+pub use crate::codec::{
+    audio_service::AudioService,
+    codec::Codec,
+    decoder,
+    discard::Discard,
+    encoder,
+    field_order::FieldOrder,
+    packet::{self, Packet},
+    subtitle::{self, Subtitle},
+    threading,
+};
 
 #[cfg(feature = "device")]
 pub mod device;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
 #![allow(non_camel_case_types)]
-#![allow(clippy::missing_safety_doc)]
 #![allow(clippy::module_inception)]
 // FFI Types may differ across platforms, making casts necessary
 #![allow(clippy::unnecessary_cast)]
 // This lint sometimes suggests worse code. See rust-lang/rust-clippy#13514
 #![allow(clippy::needless_lifetimes)]
+// TODO: Add safety docs and remove this #[allow]
+#![allow(clippy::missing_safety_doc)]
 
 pub use ffmpeg_sys_the_third as sys;
 pub use ffmpeg_sys_the_third as ffi;

--- a/src/software/resampling/flag.rs
+++ b/src/software/resampling/flag.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     pub struct Flags: c_int {
         const FORCE = SWR_FLAG_RESAMPLE;
     }

--- a/src/software/scaling/context.rs
+++ b/src/software/scaling/context.rs
@@ -78,6 +78,7 @@ impl Context {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn cached(
         &mut self,
         src_format: format::Pixel,

--- a/src/software/scaling/flag.rs
+++ b/src/software/scaling/flag.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     pub struct Flags: c_int {
         const FAST_BILINEAR        = SWS_FAST_BILINEAR;
         const BILINEAR             = SWS_BILINEAR;

--- a/src/util/channel_layout/mask.rs
+++ b/src/util/channel_layout/mask.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_ulonglong;
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Eq, PartialEq, Copy, Clone, Debug)]
     pub struct ChannelLayoutMask: c_ulonglong {
         const FRONT_LEFT            = AV_CH_FRONT_LEFT;

--- a/src/util/frame/flag.rs
+++ b/src/util/frame/flag.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     pub struct Flags: c_int {
         const CORRUPT = AV_FRAME_FLAG_CORRUPT;
     }

--- a/src/util/log/flag.rs
+++ b/src/util/log/flag.rs
@@ -1,7 +1,7 @@
 use crate::ffi::*;
 use libc::c_int;
 
-bitflags! {
+bitflags::bitflags! {
     pub struct Flags: c_int {
         const SKIP_REPEATED = AV_LOG_SKIP_REPEATED;
         const PRINT_LEVEL = AV_LOG_PRINT_LEVEL;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,7 +1,7 @@
-pub mod dictionary;
 pub mod channel_layout;
 pub mod chroma;
 pub mod color;
+pub mod dictionary;
 pub mod error;
 pub mod format;
 pub mod frame;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 pub mod dictionary;
 pub mod channel_layout;
 pub mod chroma;

--- a/src/util/option/mod.rs
+++ b/src/util/option/mod.rs
@@ -6,7 +6,7 @@ use libc::c_uint;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub struct Type: c_uint {


### PR DESCRIPTION
A bit opinionated, but I don't think controversial:

- remove `extern crate` statements, it's a remnant of edition 2015 and would never be used in new code
- delete a file that's been empty for 10 years
- remove `#[macro_use]`. [scoping rules](https://doc.rust-lang.org/reference/macros-by-example.html#r-macro.decl.scope) for macros are a bit bad because compatibility, but we can sidestep a lot of the weirdness by opting out of `macro_use` (preferably `macro_export` too) and just treating them like items
- reenable `clippy::too_many_arguments` with an exception for one public API function
- set a goal to reenable `clippy::missing_safety_docs`

I checked that this has no effect on the public API with cargo-public-api.