### PR TITLE
Add remaining codec media types

### DIFF
--- a/src/codec/codec.rs
+++ b/src/codec/codec.rs
@@ -19,6 +19,9 @@ pub fn list_descriptors() -> CodecDescriptorIter {
 
 pub type Audio = Codec<AudioType>;
 pub type Video = Codec<VideoType>;
+pub type Data = Codec<DataType>;
+pub type Subtitle = Codec<SubtitleType>;
+pub type Attachment = Codec<AttachmentType>;
 
 #[derive(PartialEq, Eq, Copy, Clone)]
 pub struct Codec<Type = UnknownType> {
@@ -29,9 +32,15 @@ pub struct Codec<Type = UnknownType> {
 #[derive(PartialEq, Eq, Copy, Clone)]
 pub struct UnknownType;
 #[derive(PartialEq, Eq, Copy, Clone)]
+pub struct VideoType;
+#[derive(PartialEq, Eq, Copy, Clone)]
 pub struct AudioType;
 #[derive(PartialEq, Eq, Copy, Clone)]
-pub struct VideoType;
+pub struct DataType;
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub struct SubtitleType;
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub struct AttachmentType;
 
 unsafe impl<T> Send for Codec<T> {}
 unsafe impl<T> Sync for Codec<T> {}

--- a/src/codec/codec.rs
+++ b/src/codec/codec.rs
@@ -55,6 +55,76 @@ impl Codec<UnknownType> {
             _marker: PhantomData,
         })
     }
+
+    // Helper function to easily convert to another codec type.
+    // TODO: Does this need to be unsafe?
+    /// Ensure that `self.medium()` is correct for `Codec<U>`.
+    fn as_other_codec<U>(self) -> Codec<U> {
+        Codec {
+            ptr: self.ptr,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn is_video(&self) -> bool {
+        self.medium() == media::Type::Video
+    }
+
+    pub fn video(self) -> Option<Video> {
+        if self.is_video() {
+            Some(self.as_other_codec())
+        } else {
+            None
+        }
+    }
+
+    pub fn is_audio(&self) -> bool {
+        self.medium() == media::Type::Audio
+    }
+
+    pub fn audio(self) -> Option<Audio> {
+        if self.is_audio() {
+            Some(self.as_other_codec())
+        } else {
+            None
+        }
+    }
+
+    pub fn is_data(&self) -> bool {
+        self.medium() == media::Type::Data
+    }
+
+    pub fn data(self) -> Option<Data> {
+        if self.is_data() {
+            Some(self.as_other_codec())
+        } else {
+            None
+        }
+    }
+
+    pub fn is_subtitle(&self) -> bool {
+        self.medium() == media::Type::Subtitle
+    }
+
+    pub fn subtitle(self) -> Option<Subtitle> {
+        if self.is_subtitle() {
+            Some(self.as_other_codec())
+        } else {
+            None
+        }
+    }
+
+    pub fn is_attachment(&self) -> bool {
+        self.medium() == media::Type::Attachment
+    }
+
+    pub fn attachment(self) -> Option<Attachment> {
+        if self.is_attachment() {
+            Some(self.as_other_codec())
+        } else {
+            None
+        }
+    }
 }
 
 impl<T> Codec<T> {
@@ -84,36 +154,6 @@ impl<T> Codec<T> {
 
     pub fn id(&self) -> Id {
         unsafe { Id::from((*self.as_ptr()).id) }
-    }
-
-    pub fn is_video(&self) -> bool {
-        self.medium() == media::Type::Video
-    }
-
-    pub fn video(self) -> Option<Video> {
-        if self.medium() == media::Type::Video {
-            Some(Codec {
-                ptr: self.ptr,
-                _marker: PhantomData,
-            })
-        } else {
-            None
-        }
-    }
-
-    pub fn is_audio(&self) -> bool {
-        self.medium() == media::Type::Audio
-    }
-
-    pub fn audio(self) -> Option<Audio> {
-        if self.medium() == media::Type::Audio {
-            Some(Codec {
-                ptr: self.ptr,
-                _marker: PhantomData,
-            })
-        } else {
-            None
-        }
     }
 
     pub fn max_lowres(&self) -> i32 {


### PR DESCRIPTION
They don't have specialized impl blocks yet, but this should at least allow differentiating between the different codec types.

Also moved the `is_video()` and `video()` (= `as_video()`) functions from `impl<T> Codec<T>` into `impl Codec<UnknownType>` because it's really only useful for codecs with an unknown type.