### PR TITLE
Create crate-wide `iters` module

### DIFF
--- a/src/codec/codec.rs
+++ b/src/codec/codec.rs
@@ -1,13 +1,12 @@
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 
-use super::config::{
-    FrameRateIter, PixelFormatIter, SampleFormatIter, SampleRateIter, TerminatedPtrIter,
-};
+use super::config::{FrameRateIter, PixelFormatIter, SampleFormatIter, SampleRateIter};
 use super::descriptor::{CodecDescriptor, CodecDescriptorIter};
 use super::profile::ProfileIter;
 use super::{Capabilities, Id};
 use crate::ffi::*;
+use crate::iters::TerminatedPtrIter;
 use crate::{media, utils};
 
 #[cfg(feature = "ffmpeg_7_1")]

--- a/src/codec/config.rs
+++ b/src/codec/config.rs
@@ -1,3 +1,6 @@
+use crate::iters::TerminatedPtrIter;
+
+#[cfg(feature = "ffmpeg_7_1")]
 use std::ptr::NonNull;
 
 #[cfg(feature = "ffmpeg_7_1")]
@@ -99,30 +102,6 @@ where
             // nullptr -> Everything is supported
             None => Ok(Supported::All),
         }
-    }
-}
-
-/// Pointer-based iterator, stepped through via pointer arithmetic and ended
-/// when a dereferenced pointer equals a terminator value.
-pub(crate) trait TerminatedPtrIter<AVType, WrapperType>:
-    Sized + Iterator<Item = WrapperType>
-{
-    /// Create a new iterator from a non-null pointer to any value in the iteration.
-    ///
-    /// # Safety
-    ///
-    /// `ptr` and all following pointers must be dereferenceable until the terminator is reached.
-    unsafe fn from_ptr(ptr: NonNull<AVType>) -> Self;
-
-    /// Create a new iterator from a pointer to any value in the iteration.
-    ///
-    /// Returns `None` if `ptr` is null. See also [`from_ptr`][TerminatedPtrIter::from_ptr].
-    ///
-    /// # Safety
-    ///
-    /// See [`from_ptr`][TerminatedPtrIter::from_ptr].
-    unsafe fn from_raw(ptr: *const AVType) -> Option<Self> {
-        unsafe { NonNull::new(ptr as *mut _).map(|ptr| Self::from_ptr(ptr)) }
     }
 }
 

--- a/src/iters.rs
+++ b/src/iters.rs
@@ -1,0 +1,25 @@
+use std::ptr::NonNull;
+
+/// Pointer-based iterator, stepped through via pointer arithmetic and ended
+/// when a dereferenced pointer equals a terminator value.
+pub(crate) trait TerminatedPtrIter<AVType, WrapperType>:
+    Sized + Iterator<Item = WrapperType>
+{
+    /// Create a new iterator from a non-null pointer to any value in the iteration.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` and all following pointers must be dereferenceable until the terminator is reached.
+    unsafe fn from_ptr(ptr: NonNull<AVType>) -> Self;
+
+    /// Create a new iterator from a pointer to any value in the iteration.
+    ///
+    /// Returns `None` if `ptr` is null. See also [`from_ptr`][TerminatedPtrIter::from_ptr].
+    ///
+    /// # Safety
+    ///
+    /// See [`from_ptr`][TerminatedPtrIter::from_ptr].
+    unsafe fn from_raw(ptr: *const AVType) -> Option<Self> {
+        unsafe { NonNull::new(ptr as *mut _).map(|ptr| Self::from_ptr(ptr)) }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub mod software;
 mod as_ptr;
 pub use as_ptr::{AsMutPtr, AsPtr};
 
+pub(crate) mod iters;
 pub(crate) mod macros;
 pub(crate) mod utils;
 


### PR DESCRIPTION
Small reorganization, could be useful for bigger changes later on.

Non-breaking change as everything changed is pub(crate) at most.
