### PR TITLE
Pick libclang version

### DIFF
--- a/ffmpeg-sys-the-third/Cargo.toml
+++ b/ffmpeg-sys-the-third/Cargo.toml
@@ -33,6 +33,8 @@ cc = "1.0"
 pkg-config = "0.3"
 bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
 clang = { version = "2.0.0", features = ["clang_3_9", "runtime"] }
+regex = "1.11.1"
+glob = "0.3.3"
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"


### PR DESCRIPTION
Hi,

I had a problem building due to having `llvm-22` installed for other reasons (eBPF) 

I added some code to the build script to pick an older version, from my testing version `19` works.

For reference, when generating bindings with clang-22 it produces some opaque structs namely `AvFormatContext` which results in build errors due to size tests.

***DID NOT TEST ON WINDOWS/MAC***