### PR TITLE
Fix/ignore newer CI errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,11 @@ jobs:
   msrv:
     runs-on: ubuntu-22.04
 
+    env:
+      # Sometimes we allow lints on newer compiler versions
+      # Without -Aunknown-lints, this would error out
+      RUSTFLAGS: "-Dwarnings -Aunknown-lints"
+
     steps:
       - uses: actions/checkout@v4
       - name: Download FFmpeg

--- a/ffmpeg-sys-the-third/src/lib.rs
+++ b/ffmpeg-sys-the-third/src/lib.rs
@@ -7,6 +7,9 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
 
+// see rust-lang/rust-bindgen#3241
+#![allow(unnecessary_transmutes)]
+
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 mod avutil;

--- a/ffmpeg-sys-the-third/src/lib.rs
+++ b/ffmpeg-sys-the-third/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(unpredictable_function_pointer_comparisons)]
 #![allow(clippy::approx_constant)]
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::redundant_static_lifetimes)]

--- a/src/codec/codec.rs
+++ b/src/codec/codec.rs
@@ -195,7 +195,7 @@ impl Codec<AudioType> {
         supported_sample_rates(self, None).expect("audio codec returns supported sample rates")
     }
 
-    pub fn rates(&self) -> Option<SampleRateIter> {
+    pub fn rates(&self) -> Option<SampleRateIter<'_>> {
         unsafe { SampleRateIter::from_raw((*self.as_ptr()).supported_samplerates) }
     }
 
@@ -212,7 +212,7 @@ impl Codec<AudioType> {
         supported_sample_formats(self, None).expect("audio codec returns supported sample formats")
     }
 
-    pub fn formats(&self) -> Option<SampleFormatIter> {
+    pub fn formats(&self) -> Option<SampleFormatIter<'_>> {
         unsafe { SampleFormatIter::from_raw((*self.as_ptr()).sample_fmts) }
     }
 
@@ -222,7 +222,7 @@ impl Codec<AudioType> {
     }
 
     #[cfg(feature = "ffmpeg_5_1")]
-    pub fn ch_layouts(&self) -> Option<ChannelLayoutIter> {
+    pub fn ch_layouts(&self) -> Option<ChannelLayoutIter<'_>> {
         unsafe { ChannelLayoutIter::from_raw((*self.as_ptr()).ch_layouts) }
     }
 }
@@ -241,7 +241,7 @@ impl Codec<VideoType> {
         supported_frame_rates(self, None).expect("video codec returns supported frame rates")
     }
 
-    pub fn rates(&self) -> Option<FrameRateIter> {
+    pub fn rates(&self) -> Option<FrameRateIter<'_>> {
         unsafe { FrameRateIter::from_raw((*self.as_ptr()).supported_framerates) }
     }
 
@@ -258,7 +258,7 @@ impl Codec<VideoType> {
         supported_pixel_formats(self, None).expect("video codec returns supported pixel formats")
     }
 
-    pub fn formats(&self) -> Option<PixelFormatIter> {
+    pub fn formats(&self) -> Option<PixelFormatIter<'_>> {
         unsafe { PixelFormatIter::from_raw((*self.as_ptr()).pix_fmts) }
     }
 

--- a/src/codec/config.rs
+++ b/src/codec/config.rs
@@ -139,7 +139,7 @@ macro_rules! impl_config_iter_fn {
         pub fn $fn_name<T>(
             codec: Codec<T>,
             ctx: Option<&Context>,
-        ) -> Result<Supported<$iter>, Error> {
+        ) -> Result<Supported<$iter<'_>>, Error> {
             supported(codec, ctx, $codec_cfg)
         }
     };

--- a/src/codec/decoder/audio.rs
+++ b/src/codec/decoder/audio.rs
@@ -97,7 +97,7 @@ impl Audio {
     }
 
     #[cfg(feature = "ffmpeg_5_1")]
-    pub fn ch_layout(&self) -> ChannelLayout {
+    pub fn ch_layout(&self) -> ChannelLayout<'_> {
         unsafe { ChannelLayout::from(&self.as_ptr().as_ref().unwrap().ch_layout) }
     }
 

--- a/src/codec/encoder/audio.rs
+++ b/src/codec/encoder/audio.rs
@@ -124,7 +124,7 @@ impl Audio {
     }
 
     #[cfg(feature = "ffmpeg_5_1")]
-    pub fn ch_layout(&self) -> ChannelLayout {
+    pub fn ch_layout(&self) -> ChannelLayout<'_> {
         unsafe { ChannelLayout::from(&self.as_ptr().as_ref().unwrap().ch_layout) }
     }
 

--- a/src/codec/packet/borrow.rs
+++ b/src/codec/packet/borrow.rs
@@ -11,7 +11,7 @@ pub struct Borrow<'a> {
 }
 
 impl<'a> Borrow<'a> {
-    pub fn new(data: &[u8]) -> Borrow {
+    pub fn new(data: &[u8]) -> Borrow<'_> {
         unsafe {
             let mut packet: AVPacket = mem::zeroed();
 

--- a/src/codec/packet/packet.rs
+++ b/src/codec/packet/packet.rs
@@ -54,7 +54,7 @@ impl Packet {
     }
 
     #[inline]
-    pub fn borrow(data: &[u8]) -> Borrow {
+    pub fn borrow(data: &[u8]) -> Borrow<'_> {
         Borrow::new(data)
     }
 
@@ -175,7 +175,7 @@ impl Packet {
     }
 
     #[inline]
-    pub fn side_data(&self) -> SideDataIter {
+    pub fn side_data(&self) -> SideDataIter<'_> {
         SideDataIter::new(&self.0)
     }
 

--- a/src/codec/parameters/common.rs
+++ b/src/codec/parameters/common.rs
@@ -103,7 +103,7 @@ impl_for_many! {
 
         /// Audio only
         #[cfg(feature = "ffmpeg_5_1")]
-        pub fn ch_layout(&self) -> ChannelLayout {
+        pub fn ch_layout(&self) -> ChannelLayout<'_> {
             unsafe { ChannelLayout::from(&(*self.as_ptr()).ch_layout) }
         }
 

--- a/src/codec/subtitle/mod.rs
+++ b/src/codec/subtitle/mod.rs
@@ -94,15 +94,15 @@ impl Subtitle {
         self.0.end_display_time = value;
     }
 
-    pub fn rects(&self) -> RectIter {
+    pub fn rects(&self) -> RectIter<'_> {
         RectIter::new(&self.0)
     }
 
-    pub fn rects_mut(&mut self) -> RectMutIter {
+    pub fn rects_mut(&'_ mut self) -> RectMutIter<'_> {
         RectMutIter::new(&mut self.0)
     }
 
-    pub fn add_rect(&mut self, kind: Type) -> RectMut {
+    pub fn add_rect(&mut self, kind: Type) -> RectMut<'_> {
         unsafe {
             self.0.num_rects += 1;
             self.0.rects = av_realloc(

--- a/src/device/extensions.rs
+++ b/src/device/extensions.rs
@@ -8,7 +8,7 @@ use crate::Error;
 use libc::c_int;
 
 impl Context {
-    pub fn devices(&self) -> Result<DeviceIter, Error> {
+    pub fn devices(&self) -> Result<DeviceIter<'_>, Error> {
         unsafe { DeviceIter::wrap(self.as_ptr()) }
     }
 }

--- a/src/filter/filter.rs
+++ b/src/filter/filter.rs
@@ -31,7 +31,7 @@ impl Filter {
         unsafe { utils::optional_str_from_c_ptr((*self.as_ptr()).description) }
     }
 
-    pub fn inputs(&self) -> Option<PadIter> {
+    pub fn inputs(&self) -> Option<PadIter<'_>> {
         unsafe {
             let ptr = (*self.as_ptr()).inputs;
 
@@ -48,7 +48,7 @@ impl Filter {
         }
     }
 
-    pub fn outputs(&self) -> Option<PadIter> {
+    pub fn outputs(&self) -> Option<PadIter<'_>> {
         unsafe {
             let ptr = (*self.as_ptr()).outputs;
 

--- a/src/filter/graph.rs
+++ b/src/filter/graph.rs
@@ -106,11 +106,11 @@ impl Graph {
         }
     }
 
-    pub fn input(&mut self, name: &str, pad: usize) -> Result<Parser, Error> {
+    pub fn input(&mut self, name: &str, pad: usize) -> Result<Parser<'_>, Error> {
         Parser::new(self).input(name, pad)
     }
 
-    pub fn output(&mut self, name: &str, pad: usize) -> Result<Parser, Error> {
+    pub fn output(&mut self, name: &str, pad: usize) -> Result<Parser<'_>, Error> {
         Parser::new(self).output(name, pad)
     }
 
@@ -134,7 +134,7 @@ pub struct Parser<'a> {
 }
 
 impl<'a> Parser<'a> {
-    pub fn new(graph: &mut Graph) -> Parser {
+    pub fn new(graph: &mut Graph) -> Parser<'_> {
         Parser {
             graph,
             inputs: ptr::null_mut(),

--- a/src/format/chapter/chapter.rs
+++ b/src/format/chapter/chapter.rs
@@ -11,7 +11,7 @@ pub struct Chapter<'a> {
 }
 
 impl<'a> Chapter<'a> {
-    pub unsafe fn wrap(context: &Context, index: usize) -> Chapter {
+    pub unsafe fn wrap(context: &Context, index: usize) -> Chapter<'_> {
         Chapter { context, index }
     }
 
@@ -41,7 +41,7 @@ impl<'a> Chapter<'a> {
         unsafe { (*self.as_ptr()).end }
     }
 
-    pub fn metadata(&self) -> DictionaryRef {
+    pub fn metadata(&self) -> DictionaryRef<'_> {
         unsafe { DictionaryRef::wrap((*self.as_ptr()).metadata) }
     }
 }

--- a/src/format/chapter/chapter_mut.rs
+++ b/src/format/chapter/chapter_mut.rs
@@ -16,7 +16,7 @@ pub struct ChapterMut<'a> {
 }
 
 impl<'a> ChapterMut<'a> {
-    pub unsafe fn wrap(context: &mut Context, index: usize) -> ChapterMut {
+    pub unsafe fn wrap(context: &mut Context, index: usize) -> ChapterMut<'_> {
         ChapterMut {
             context: mem::transmute_copy(&context),
             index,
@@ -65,7 +65,7 @@ impl<'a> ChapterMut<'a> {
         }
     }
 
-    pub fn metadata(&mut self) -> DictionaryMut {
+    pub fn metadata(&mut self) -> DictionaryMut<'_> {
         unsafe { DictionaryMut::wrap((*self.as_mut_ptr()).metadata) }
     }
 }

--- a/src/format/context/common.rs
+++ b/src/format/context/common.rs
@@ -68,11 +68,11 @@ impl Context {
         }
     }
 
-    pub fn streams(&self) -> StreamIter {
+    pub fn streams(&self) -> StreamIter<'_> {
         StreamIter::new(self)
     }
 
-    pub fn streams_mut(&mut self) -> StreamIterMut {
+    pub fn streams_mut(&mut self) -> StreamIterMut<'_> {
         StreamIterMut::new(self)
     }
 
@@ -115,15 +115,15 @@ impl Context {
         }
     }
 
-    pub fn chapters(&self) -> ChapterIter {
+    pub fn chapters(&self) -> ChapterIter<'_> {
         ChapterIter::new(self)
     }
 
-    pub fn chapters_mut(&mut self) -> ChapterIterMut {
+    pub fn chapters_mut(&mut self) -> ChapterIterMut<'_> {
         ChapterIterMut::new(self)
     }
 
-    pub fn metadata(&self) -> DictionaryRef {
+    pub fn metadata(&self) -> DictionaryRef<'_> {
         unsafe { DictionaryRef::wrap((*self.as_ptr()).metadata) }
     }
 }

--- a/src/format/context/input.rs
+++ b/src/format/context/input.rs
@@ -74,7 +74,7 @@ impl Input {
         unsafe { (*self.as_ptr()).probe_score }
     }
 
-    pub fn packets(&mut self) -> PacketIter {
+    pub fn packets(&mut self) -> PacketIter<'_> {
         PacketIter::new(self)
     }
 
@@ -137,7 +137,7 @@ pub struct PacketIter<'a> {
 }
 
 impl<'a> PacketIter<'a> {
-    pub fn new(context: &mut Input) -> PacketIter {
+    pub fn new(context: &mut Input) -> PacketIter<'_> {
         PacketIter { context }
     }
 }

--- a/src/format/context/output.rs
+++ b/src/format/context/output.rs
@@ -47,7 +47,7 @@ impl Output {
         }
     }
 
-    pub fn write_header_with(&mut self, options: Dictionary) -> Result<Dictionary, Error> {
+    pub fn write_header_with(&mut self, options: Dictionary) -> Result<Dictionary<'_>, Error> {
         unsafe {
             let mut opts = options.disown();
             let res = avformat_write_header(self.as_mut_ptr(), &mut opts);
@@ -68,7 +68,10 @@ impl Output {
         }
     }
 
-    pub fn add_stream<T, E: traits::Encoder<T>>(&mut self, codec: E) -> Result<StreamMut, Error> {
+    pub fn add_stream<T, E: traits::Encoder<T>>(
+        &mut self,
+        codec: E,
+    ) -> Result<StreamMut<'_>, Error> {
         unsafe {
             let codec = codec.encoder();
             let codec = codec.map_or(ptr::null(), |c| c.as_ptr());
@@ -91,7 +94,7 @@ impl Output {
         start: i64,
         end: i64,
         title: S,
-    ) -> Result<ChapterMut, Error> {
+    ) -> Result<ChapterMut<'_>, Error> {
         // avpriv_new_chapter is private (libavformat/internal.h)
 
         if start > end {

--- a/src/format/stream/stream.rs
+++ b/src/format/stream/stream.rs
@@ -12,7 +12,7 @@ pub struct Stream<'a> {
 }
 
 impl<'a> Stream<'a> {
-    pub unsafe fn wrap(context: &Context, index: usize) -> Stream {
+    pub unsafe fn wrap(context: &Context, index: usize) -> Stream<'_> {
         Stream { context, index }
     }
 
@@ -31,7 +31,7 @@ impl<'a> Stream<'a> {
         unsafe { codec::Context::wrap((*self.as_ptr()).codec, Some(self.context.destructor())) }
     }
 
-    pub fn parameters(&self) -> codec::ParametersRef {
+    pub fn parameters(&self) -> codec::ParametersRef<'_> {
         unsafe {
             codec::ParametersRef::from_raw((*self.as_ptr()).codecpar).expect("codecpar is non-null")
         }
@@ -65,7 +65,7 @@ impl<'a> Stream<'a> {
         unsafe { Discard::from((*self.as_ptr()).discard) }
     }
 
-    pub fn side_data(&self) -> SideDataIter {
+    pub fn side_data(&self) -> SideDataIter<'_> {
         SideDataIter::new(self)
     }
 
@@ -77,7 +77,7 @@ impl<'a> Stream<'a> {
         unsafe { Rational::from((*self.as_ptr()).avg_frame_rate) }
     }
 
-    pub fn metadata(&self) -> DictionaryRef {
+    pub fn metadata(&self) -> DictionaryRef<'_> {
         unsafe { DictionaryRef::wrap((*self.as_ptr()).metadata) }
     }
 }

--- a/src/format/stream/stream_mut.rs
+++ b/src/format/stream/stream_mut.rs
@@ -15,7 +15,7 @@ pub struct StreamMut<'a> {
 }
 
 impl<'a> StreamMut<'a> {
-    pub unsafe fn wrap(context: &mut Context, index: usize) -> StreamMut {
+    pub unsafe fn wrap(context: &mut Context, index: usize) -> StreamMut<'_> {
         StreamMut {
             context: mem::transmute_copy(&context),
             index,
@@ -48,7 +48,7 @@ impl<'a> StreamMut<'a> {
         }
     }
 
-    pub fn parameters_mut(&mut self) -> codec::ParametersMut {
+    pub fn parameters_mut(&mut self) -> codec::ParametersMut<'_> {
         unsafe {
             codec::ParametersMut::from_raw((*self.as_mut_ptr()).codecpar)
                 .expect("codecpar is non-null")

--- a/src/software/scaling/filter.rs
+++ b/src/software/scaling/filter.rs
@@ -43,35 +43,35 @@ impl Filter {
         Self::get(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     }
 
-    pub fn luma_horizontal(&self) -> Vector {
+    pub fn luma_horizontal(&self) -> Vector<'_> {
         unsafe { Vector::wrap((*self.as_ptr()).lumH) }
     }
 
-    pub fn luma_horizontal_mut(&mut self) -> Vector {
+    pub fn luma_horizontal_mut(&mut self) -> Vector<'_> {
         unsafe { Vector::wrap((*self.as_mut_ptr()).lumH) }
     }
 
-    pub fn luma_vertical(&self) -> Vector {
+    pub fn luma_vertical(&self) -> Vector<'_> {
         unsafe { Vector::wrap((*self.as_ptr()).lumV) }
     }
 
-    pub fn luma_vertical_mut(&mut self) -> Vector {
+    pub fn luma_vertical_mut(&mut self) -> Vector<'_> {
         unsafe { Vector::wrap((*self.as_mut_ptr()).lumV) }
     }
 
-    pub fn chroma_horizontal(&self) -> Vector {
+    pub fn chroma_horizontal(&self) -> Vector<'_> {
         unsafe { Vector::wrap((*self.as_ptr()).lumV) }
     }
 
-    pub fn chroma_horizontal_mut(&mut self) -> Vector {
+    pub fn chroma_horizontal_mut(&mut self) -> Vector<'_> {
         unsafe { Vector::wrap((*self.as_mut_ptr()).lumV) }
     }
 
-    pub fn chroma_vertical(&self) -> Vector {
+    pub fn chroma_vertical(&self) -> Vector<'_> {
         unsafe { Vector::wrap((*self.as_ptr()).lumV) }
     }
 
-    pub fn chroma_vertical_mut(&mut self) -> Vector {
+    pub fn chroma_vertical_mut(&mut self) -> Vector<'_> {
         unsafe { Vector::wrap((*self.as_mut_ptr()).lumV) }
     }
 }

--- a/src/util/dictionary/immutable.rs
+++ b/src/util/dictionary/immutable.rs
@@ -42,7 +42,7 @@ impl<'a> Ref<'a> {
         }
     }
 
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         unsafe { Iter::new(self.as_ptr()) }
     }
 

--- a/src/util/frame/audio.rs
+++ b/src/util/frame/audio.rs
@@ -95,7 +95,7 @@ impl Audio {
 
     #[cfg(feature = "ffmpeg_5_1")]
     #[inline]
-    pub fn ch_layout(&self) -> ChannelLayout {
+    pub fn ch_layout(&self) -> ChannelLayout<'_> {
         unsafe { ChannelLayout::from(&self.as_ref().unwrap().ch_layout) }
     }
 

--- a/src/util/frame/mod.rs
+++ b/src/util/frame/mod.rs
@@ -141,7 +141,7 @@ impl Frame {
     }
 
     #[inline]
-    pub fn metadata(&self) -> DictionaryRef {
+    pub fn metadata(&self) -> DictionaryRef<'_> {
         unsafe { DictionaryRef::wrap((*self.as_ptr()).metadata) }
     }
 
@@ -151,7 +151,7 @@ impl Frame {
     }
 
     #[inline]
-    pub fn side_data(&self, kind: side_data::Type) -> Option<SideData> {
+    pub fn side_data(&self, kind: side_data::Type) -> Option<SideData<'_>> {
         unsafe {
             let ptr = av_frame_get_side_data(self.as_ptr(), kind.into());
 
@@ -164,7 +164,7 @@ impl Frame {
     }
 
     #[inline]
-    pub fn new_side_data(&mut self, kind: side_data::Type, size: usize) -> Option<SideData> {
+    pub fn new_side_data(&mut self, kind: side_data::Type, size: usize) -> Option<SideData<'_>> {
         unsafe {
             let ptr = av_frame_new_side_data(self.as_mut_ptr(), kind.into(), size as _);
 

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -244,7 +244,7 @@ impl<'a> SideData<'a> {
     }
 
     #[inline]
-    pub fn metadata(&self) -> DictionaryRef {
+    pub fn metadata(&self) -> DictionaryRef<'_> {
         unsafe { DictionaryRef::wrap((*self.as_ptr()).metadata) }
     }
 }


### PR DESCRIPTION
The pointer comparison lint is valid and the `PartialEq`/`Eq` derives should probably be removed with the next major patch. I'd assume the derives are generally unused and API users would be surprised by this if they do use equality checks.

The lifetime change could be resolved in a few ways:

```rust
struct SomeType<'a> {}

pub fn rates(&self) -> SomeType {}
```

could turn into

```rust
pub fn rates(&'a self) -> SomeType<'a> {}
```

or

```rust
pub fn rates(&self) -> SomeType<'_> {}
```

or

```rust
pub fn rates(&'_ self) -> SomeType<'_> {}
```

I think the first two are acceptable and I just decided on option #2.