### PR TITLE
Update build script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,6 @@ build-license-nonfree = ["ffmpeg-sys-the-third/build-license-nonfree"]
 build-license-version3 = ["ffmpeg-sys-the-third/build-license-version3"]
 
 # misc
-build-pic = ["ffmpeg-sys-the-third/build-pic"]
 build-zlib = ["ffmpeg-sys-the-third/build-zlib"]
 
 # ssl

--- a/build.rs
+++ b/build.rs
@@ -6,12 +6,12 @@ fn main() {
 
         if name.starts_with("DEP_FFMPEG_CHECK_") {
             println!(
-                r#"cargo:rustc-check-cfg=cfg(feature, values("{}"))"#,
+                r#"cargo::rustc-check-cfg=cfg(feature, values("{}"))"#,
                 name["DEP_FFMPEG_CHECK_".len()..name.len()].to_lowercase()
             );
         } else if name.starts_with("DEP_FFMPEG_") {
             println!(
-                r#"cargo:rustc-cfg=feature="{}""#,
+                r#"cargo::rustc-cfg=feature="{}""#,
                 name["DEP_FFMPEG_".len()..name.len()].to_lowercase()
             );
         }

--- a/ffmpeg-sys-the-third/Cargo.toml
+++ b/ffmpeg-sys-the-third/Cargo.toml
@@ -94,7 +94,6 @@ build-license-version3 = ["build"]
 # misc
 build-drm = ["build"]
 build-nvenc = ["build"]
-build-pic = ["build"]
 build-zlib = ["build"]
 
 # ssl

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -373,14 +373,6 @@ fn cargo_feature_enabled(feature: &str) -> bool {
     env::var(format!("CARGO_FEATURE_{}", feature.to_uppercase())).is_ok()
 }
 
-fn ffmpeg_version() -> String {
-    env!("CARGO_PKG_VERSION")
-        .split('+')
-        .nth(1)
-        .unwrap()
-        .replace("ffmpeg-", "")
-}
-
 fn output() -> PathBuf {
     PathBuf::from(env::var("OUT_DIR").unwrap())
 }
@@ -589,7 +581,6 @@ fn link_to_libraries(libraries: &[Library], statik: bool) {
 fn main() {
     let out_dir = output();
     let statik = cargo_feature_enabled("static");
-    let ffmpeg_version = ffmpeg_version();
 
     let all_libraries = [
         Library::required("avutil", AVUTIL_FEATURES, AVUTIL_HEADERS, 57),
@@ -607,7 +598,7 @@ fn main() {
         .collect();
 
     let include_paths: Vec<PathBuf> = if cargo_feature_enabled("build") {
-        let install_dir = compile::build(&enabled_libraries, &out_dir, &ffmpeg_version).unwrap();
+        let install_dir = compile::build(&enabled_libraries, &out_dir).unwrap();
         println!(
             "cargo:rustc-link-search=native={}",
             install_dir.join("lib").to_string_lossy()

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::env;
 use std::fmt::Write as FmtWrite;
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -10,6 +10,7 @@ use std::str;
 use bindgen::callbacks::{
     EnumVariantCustomBehavior, EnumVariantValue, IntKind, MacroParsingBehavior, ParseCallbacks,
 };
+use bindgen::EnumVariation;
 
 #[derive(Debug)]
 struct Library {
@@ -216,14 +217,30 @@ static SWSCALE_FEATURES: &[AVFeature] = &[];
 
 static SWRESAMPLE_FEATURES: &[AVFeature] = &[];
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 struct AVHeader {
     name: &'static str,
+    from_ver: Option<u64>,
+    to_ver: Option<u64>,
 }
 
 impl AVHeader {
     const fn new(name: &'static str) -> Self {
-        Self { name }
+        Self {
+            name,
+            from_ver: None,
+            to_ver: None,
+        }
+    }
+
+    const fn from_ver(mut self, ver: u64) -> Self {
+        self.from_ver = Some(ver);
+        self
+    }
+
+    const fn to_ver(mut self, ver: u64) -> Self {
+        self.to_ver = Some(ver);
+        self
     }
 }
 
@@ -251,6 +268,7 @@ static AVUTIL_HEADERS: &[AVHeader] = &[
     AVHeader::new("hash.h"),
     AVHeader::new("hmac.h"),
     AVHeader::new("hwcontext.h"),
+    AVHeader::new("hwcontext_drm.h"),
     AVHeader::new("imgutils.h"),
     AVHeader::new("lfg.h"),
     AVHeader::new("log.h"),
@@ -278,14 +296,14 @@ static AVUTIL_HEADERS: &[AVHeader] = &[
     AVHeader::new("time.h"),
     AVHeader::new("timecode.h"),
     AVHeader::new("twofish.h"),
-    // AVHeader::new("tx.h"),
+    AVHeader::new("tx.h").from_ver(60), // post-8.0
     AVHeader::new("avutil.h"),
     AVHeader::new("xtea.h"),
 ];
 static AVCODEC_HEADERS: &[AVHeader] = &[
     AVHeader::new("avcodec.h"),
     AVHeader::new("dv_profile.h"),
-    // AVHeader::new("avfft.h"), TODO: Make these things version-aware
+    AVHeader::new("avfft.h").to_ver(61), // pre-8.0
     AVHeader::new("vorbis_parser.h"),
 ];
 static AVFORMAT_HEADERS: &[AVHeader] = &[AVHeader::new("avformat.h"), AVHeader::new("avio.h")];
@@ -828,25 +846,6 @@ fn check_features(include_paths: &[PathBuf]) -> u64 {
     lavc_version.0
 }
 
-fn search_include(include_paths: &[PathBuf], header: &str) -> String {
-    for dir in include_paths {
-        let include = dir.join(header);
-        if fs::metadata(&include).is_ok() {
-            return include.as_path().to_str().unwrap().to_string();
-        }
-    }
-    format!("/usr/include/{}", header)
-}
-
-fn maybe_search_include(include_paths: &[PathBuf], header: &str) -> Option<String> {
-    let path = search_include(include_paths, header);
-    if fs::metadata(&path).is_ok() {
-        Some(path)
-    } else {
-        None
-    }
-}
-
 fn link_to_libraries(statik: bool) {
     let ffmpeg_ty = if statik { "static" } else { "dylib" };
     for lib in LIBRARIES.iter().filter(|lib| lib.enabled()) {
@@ -936,16 +935,27 @@ fn main() {
         }
     }
 
-    let lavc_major_ver = check_features(&include_paths);
+    check_features(&include_paths);
+
+    let mut wrapper_h = String::with_capacity(2048);
+
+    for lib in LIBRARIES.iter().filter(|lib| lib.enabled()) {
+        for header in lib.headers {
+            add_include(&mut wrapper_h, lib, header).expect("failed to write to String");
+        }
+    }
+
+    // eprintln!("wrapper header: {wrapper_h}");
 
     let clang_includes = include_paths
         .iter()
         .map(|include| format!("-I{}", include.to_string_lossy()));
 
-    // The bindgen::Builder is the main entry point
-    // to bindgen, and lets you build up options for
-    // the resulting bindings.
-    let mut builder = bindgen::Builder::default()
+    let default_enum_style = EnumVariation::Rust {
+        non_exhaustive: cargo_feature_enabled("non_exhaustive_enums"),
+    };
+
+    bindgen::Builder::default()
         .clang_args(clang_includes)
         .ctypes_prefix("libc")
         // Not trivially copyable
@@ -953,10 +963,12 @@ fn main() {
         // We need/want to implement Debug by hand for some types
         .no_debug("AVChannelLayout")
         .no_debug("AVChannelCustom")
+        .default_enum_style(default_enum_style)
         // Some enums can never be rustified, use the newtype
         // pattern for them instead.
         .newtype_enum("AVOptionType")
         .newtype_enum("AVAlphaMode")
+        // Only generate bindings from FFmpeg headers
         .allowlist_file(r#".*[/\\]libavutil[/\\].*"#)
         .allowlist_file(r#".*[/\\]libavcodec[/\\].*"#)
         .allowlist_file(r#".*[/\\]libavformat[/\\].*"#)
@@ -968,46 +980,38 @@ fn main() {
         .prepend_enum_name(false)
         .derive_eq(true)
         .size_t_is_usize(true)
-        .parse_callbacks(Box::new(Callbacks));
-
-    if cargo_feature_enabled("non_exhaustive_enums") {
-        builder = builder.rustified_non_exhaustive_enum(".*");
-    } else {
-        builder = builder.rustified_enum(".*");
-    }
-
-    // The input headers we would like to generate
-    // bindings for.
-    for lib in LIBRARIES.iter().filter(|lib| lib.enabled()) {
-        for header in lib.headers {
-            builder = builder.header(search_include(
-                &include_paths,
-                &format!("lib{}/{}", lib.name, header.name),
-            ));
-        }
-
-        // HACK: if pre-8.0
-        if lavc_major_ver < 62 {
-            builder = builder.header(search_include(&include_paths, "libavcodec/avfft.h"));
-        } else {
-            builder = builder.header(search_include(&include_paths, "libavutil/tx.h"));
-        }
-    }
-
-    if let Some(hwcontext_drm_header) =
-        maybe_search_include(&include_paths, "libavutil/hwcontext_drm.h")
-    {
-        builder = builder.header(hwcontext_drm_header);
-    }
-
-    // Finish the builder and generate the bindings.
-    let bindings = builder
+        .parse_callbacks(Box::new(Callbacks))
+        .header_contents("wrapper.h", &wrapper_h)
         .generate()
-        // Unwrap the Result and panic on failure.
-        .expect("Unable to generate bindings");
-
-    // Write the bindings to the $OUT_DIR/bindings.rs file.
-    bindings
+        .expect("Unable to generate bindings")
         .write_to_file(out_dir.join("bindings.rs"))
         .expect("Couldn't write bindings!");
+}
+
+fn add_include(s: &mut String, lib: &Library, header: &AVHeader) -> std::fmt::Result {
+    let ver_name = format!("LIB{}_VERSION_MAJOR", lib.name.to_uppercase());
+
+    let end_if = match (header.from_ver, header.to_ver) {
+        (Some(from), Some(to)) => {
+            writeln!(s, "#if {ver_name} >= {from} && {ver_name} <= {to}")?;
+            true
+        }
+        (Some(from), None) => {
+            writeln!(s, "#if {ver_name} >= {from}")?;
+            true
+        }
+        (None, Some(to)) => {
+            writeln!(s, "#if {ver_name} <= {to}")?;
+            true
+        }
+        (None, None) => false,
+    };
+
+    writeln!(s, r#"#include "lib{}/{}""#, lib.name, header.name)?;
+
+    if end_if {
+        writeln!(s, "#endif")?;
+    }
+
+    Ok(())
 }

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -373,10 +373,6 @@ fn cargo_feature_enabled(feature: &str) -> bool {
     env::var(format!("CARGO_FEATURE_{}", feature.to_uppercase())).is_ok()
 }
 
-fn output() -> PathBuf {
-    PathBuf::from(env::var("OUT_DIR").unwrap())
-}
-
 #[cfg(not(target_env = "msvc"))]
 fn try_vcpkg(_statik: bool) -> Option<Vec<PathBuf>> {
     None
@@ -389,9 +385,7 @@ fn try_vcpkg(statik: bool) -> Option<Vec<PathBuf>> {
     }
 
     vcpkg::find_package("ffmpeg")
-        .map_err(|e| {
-            println!("Could not find ffmpeg with vcpkg: {}", e);
-        })
+        .inspect_err(|e| println!("Could not find ffmpeg with vcpkg: {e}"))
         .map(|library| library.include_paths)
         .ok()
 }
@@ -493,19 +487,19 @@ fn check_features(libraries: &[Library], include_paths: &[PathBuf]) -> u64 {
 
     for (var, (var_defined, var_enabled)) in features_defined_enabled {
         // Every possible feature needs an unconditional check-cfg to prevent warnings
-        println!(r#"cargo:rustc-check-cfg=cfg(feature, values("{}"))"#, var);
-        println!(r#"cargo:check_{}=true"#, var);
+        println!(r#"cargo::rustc-check-cfg=cfg(feature, values("{var}"))"#);
+        println!(r#"cargo::metadata=check_{var}=true"#);
 
         if var_enabled {
-            println!(r#"cargo:rustc-cfg=feature="{}""#, var);
-            println!(r#"cargo:{}=true"#, var);
+            println!(r#"cargo::rustc-cfg=feature="{var}""#);
+            println!(r#"cargo::metadata={var}=true"#);
         }
 
         // Also find out if defined or not (useful for cases where only the definition of a macro
         // can be used as distinction)
         if var_defined {
-            println!(r#"cargo:rustc-cfg=feature="{}_is_defined""#, var);
-            println!(r#"cargo:{}_is_defined=true"#, var);
+            println!(r#"cargo::rustc-cfg=feature="{var}_is_defined""#);
+            println!(r#"cargo::metadata={var}_is_defined=true"#);
         }
     }
 
@@ -519,11 +513,11 @@ fn check_features(libraries: &[Library], include_paths: &[PathBuf]) -> u64 {
             for minor in 0..=135 {
                 if *ver >= (major, minor) {
                     println!(
-                        r#"cargo:rustc-cfg=feature="{}_version_greater_than_{major}_{minor}""#,
+                        r#"cargo::rustc-cfg=feature="{}_version_greater_than_{major}_{minor}""#,
                         lib.name,
                     );
                     println!(
-                        r#"cargo:{}_version_greater_than_{major}_{minor}=true"#,
+                        r#"cargo::metadata={}_version_greater_than_{major}_{minor}=true"#,
                         lib.name,
                     );
                 }
@@ -550,17 +544,14 @@ fn check_features(libraries: &[Library], include_paths: &[PathBuf]) -> u64 {
         "FFmpeg 5.1 or higher is required, but found avcodec version {lavc_version:?}"
     );
 
-    for &(ffmpeg_version_flag, lavc_version_major, lavc_version_minor) in &ffmpeg_lavc_versions {
+    for &(ff_version, lavc_version_major, lavc_version_minor) in &ffmpeg_lavc_versions {
         // Every possible feature needs an unconditional check-cfg to prevent warnings
-        println!(
-            r#"cargo:rustc-check-cfg=cfg(feature, values("{}"))"#,
-            ffmpeg_version_flag
-        );
-        println!(r#"cargo:check_{}=true"#, ffmpeg_version_flag);
+        println!(r#"cargo::rustc-check-cfg=cfg(feature, values("{ff_version}"))"#,);
+        println!(r#"cargo::metadata=check_{ff_version}=true"#);
 
         if lavc_version >= (lavc_version_major, lavc_version_minor) {
-            println!(r#"cargo:rustc-cfg=feature="{}""#, ffmpeg_version_flag);
-            println!(r#"cargo:{}=true"#, ffmpeg_version_flag);
+            println!(r#"cargo::rustc-cfg=feature="{ff_version}""#);
+            println!(r#"cargo::metadata={ff_version}=true"#);
         }
     }
 
@@ -571,15 +562,15 @@ fn check_features(libraries: &[Library], include_paths: &[PathBuf]) -> u64 {
 fn link_to_libraries(libraries: &[Library], statik: bool) {
     let ffmpeg_ty = if statik { "static" } else { "dylib" };
     for lib in libraries {
-        println!("cargo:rustc-link-lib={}={}", ffmpeg_ty, lib.name);
+        println!("cargo::rustc-link-lib={}={}", ffmpeg_ty, lib.name);
     }
     if cargo_feature_enabled("build_zlib") && cfg!(target_os = "linux") {
-        println!("cargo:rustc-link-lib=z");
+        println!("cargo::rustc-link-lib=z");
     }
 }
 
 fn main() {
-    let out_dir = output();
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let statik = cargo_feature_enabled("static");
 
     let all_libraries = [
@@ -600,7 +591,7 @@ fn main() {
     let include_paths: Vec<PathBuf> = if cargo_feature_enabled("build") {
         let install_dir = compile::build(&enabled_libraries, &out_dir).unwrap();
         println!(
-            "cargo:rustc-link-search=native={}",
+            "cargo::rustc-link-search=native={}",
             install_dir.join("lib").to_string_lossy()
         );
         link_to_libraries(&enabled_libraries, statik);
@@ -611,7 +602,7 @@ fn main() {
     else if let Ok(ffmpeg_dir) = env::var("FFMPEG_DIR") {
         let ffmpeg_dir = PathBuf::from(ffmpeg_dir);
         println!(
-            "cargo:rustc-link-search=native={}",
+            "cargo::rustc-link-search=native={}",
             ffmpeg_dir.join("lib").to_string_lossy()
         );
         link_to_libraries(&enabled_libraries, statik);
@@ -620,17 +611,17 @@ fn main() {
         // vcpkg doesn't detect the "system" dependencies
         if statik {
             if cfg!(feature = "avcodec") || cfg!(feature = "avdevice") {
-                println!("cargo:rustc-link-lib=ole32");
+                println!("cargo::rustc-link-lib=ole32");
             }
 
             if cfg!(feature = "avformat") {
-                println!("cargo:rustc-link-lib=secur32");
-                println!("cargo:rustc-link-lib=ws2_32");
+                println!("cargo::rustc-link-lib=secur32");
+                println!("cargo::rustc-link-lib=ws2_32");
             }
 
             // avutil dependencies
-            println!("cargo:rustc-link-lib=bcrypt");
-            println!("cargo:rustc-link-lib=user32");
+            println!("cargo::rustc-link-lib=bcrypt");
+            println!("cargo::rustc-link-lib=user32");
         }
 
         paths
@@ -667,7 +658,7 @@ fn main() {
             "VideoToolbox",
         ];
         for f in frameworks {
-            println!("cargo:rustc-link-lib=framework={}", f);
+            println!("cargo::rustc-link-lib=framework={f}");
         }
     }
 

--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -1,16 +1,16 @@
 use std::collections::HashMap;
 use std::env;
 use std::fmt::Write as FmtWrite;
-use std::fs::File;
-use std::io::{self, BufRead, BufReader};
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::PathBuf;
 use std::str;
 
 use bindgen::callbacks::{
     EnumVariantCustomBehavior, EnumVariantValue, IntKind, MacroParsingBehavior, ParseCallbacks,
 };
 use bindgen::EnumVariation;
+
+#[path = "build/compile.rs"]
+mod compile;
 
 #[derive(Debug)]
 struct Library {
@@ -60,16 +60,6 @@ impl Library {
         !self.optional || cargo_feature_enabled(self.name)
     }
 }
-
-static LIBRARIES: &[Library] = &[
-    Library::required("avutil", AVUTIL_FEATURES, AVUTIL_HEADERS, 57),
-    Library::optional("avcodec", AVCODEC_FEATURES, AVCODEC_HEADERS, 59),
-    Library::optional("avformat", AVFORMAT_FEATURES, AVFORMAT_HEADERS, 59),
-    Library::optional("avdevice", AVDEVICE_FEATURES, AVDEVICE_HEADERS, 59),
-    Library::optional("avfilter", AVFILTER_FEATURES, AVFILTER_HEADERS, 8),
-    Library::optional("swscale", SWSCALE_FEATURES, SWSCALE_HEADERS, 6),
-    Library::optional("swresample", SWRESAMPLE_FEATURES, SWRESAMPLE_HEADERS, 4),
-];
 
 #[derive(Debug)]
 struct AVFeature {
@@ -379,29 +369,6 @@ impl ParseCallbacks for Callbacks {
     }
 }
 
-trait FFmpegConfigure {
-    fn switch(&mut self, feature: &str, option_name: &str);
-    fn enable(&mut self, feature: &str, option_name: &str);
-}
-
-impl FFmpegConfigure for Command {
-    fn switch(&mut self, feature: &str, option_name: &str) {
-        let arg = if cargo_feature_enabled(feature) {
-            format!("--enable-{option_name}")
-        } else {
-            format!("--disable-{option_name}")
-        };
-
-        self.arg(arg);
-    }
-
-    fn enable(&mut self, feature: &str, option_name: &str) {
-        if cargo_feature_enabled(feature) {
-            self.arg(format!("--enable-{option_name}"));
-        }
-    }
-}
-
 fn cargo_feature_enabled(feature: &str) -> bool {
     env::var(format!("CARGO_FEATURE_{}", feature.to_uppercase())).is_ok()
 }
@@ -416,245 +383,6 @@ fn ffmpeg_version() -> String {
 
 fn output() -> PathBuf {
     PathBuf::from(env::var("OUT_DIR").unwrap())
-}
-
-fn fetch(source_dir: &Path, ffmpeg_version: &str) -> io::Result<()> {
-    let _ = std::fs::remove_dir_all(source_dir);
-    let status = Command::new("git")
-        .arg("clone")
-        .arg("--depth=1")
-        .arg("-b")
-        .arg(format!("n{ffmpeg_version}"))
-        .arg("https://github.com/FFmpeg/FFmpeg")
-        .arg(source_dir)
-        .status()?;
-
-    if status.success() {
-        Ok(())
-    } else {
-        Err(io::Error::other("fetch failed"))
-    }
-}
-
-// left side: cargo feature name ("CARGO_FEATURE_BUILD_LIB_{}")
-// right side: FFmpeg configure name ("--enable-{}")
-static EXTERNAL_BUILD_LIBS: &[(&str, &str)] = &[
-    // SSL
-    ("GNUTLS", "gnutls"),
-    ("OPENSSL", "openssl"),
-    // Filters
-    ("FONTCONFIG", "fontconfig"),
-    ("FREI0R", "frei0r"),
-    ("LADSPA", "ladspa"),
-    ("ASS", "libass"),
-    ("FREETYPE", "libfreetype"),
-    ("FRIBIDI", "libfribidi"),
-    ("OPENCV", "libopencv"),
-    ("VMAF", "libvmaf"),
-    // Encoders/decoders
-    ("AACPLUS", "libaacplus"),
-    ("CELT", "libcelt"),
-    ("CODEC2", "libcodec2"),
-    ("DAV1D", "libdav1d"),
-    ("DAVS2", "libdavs2"),
-    ("DCADEC", "libdcadec"),
-    ("FAAC", "libfaac"),
-    ("FDK_AAC", "libfdk-aac"),
-    ("GSM", "libgsm"),
-    ("ILBC", "libilbc"),
-    ("JXL", "libjxl"),
-    ("KVAZAAR", "libkvazaar"),
-    ("LC3", "liblc3"),
-    ("LCEVC_DEC", "liblcevc-dec"),
-    ("MP3LAME", "libmp3lame"),
-    ("MPEGHDEC", "libmpeghdec"),
-    ("OAPV", "liboapv"),
-    ("OPENCORE_AMRNB", "libopencore-amrnb"),
-    ("OPENCORE_AMRWB", "libopencore-amrwb"),
-    ("OPENH264", "libopenh264"),
-    ("OPENH265", "libopenh265"),
-    ("OPENJPEG", "libopenjpeg"),
-    ("OPENMPT", "libopenmpt"),
-    ("OPUS", "libopus"),
-    ("RAV1E", "librav1e"),
-    ("SCHROEDINGER", "libschroedinger"),
-    ("SHINE", "libshine"),
-    ("SNAPPY", "libsnappy"),
-    ("SPEEX", "libspeex"),
-    ("STAGEFRIGHT_H264", "libstagefright-h264"),
-    ("SVTAV1", "libsvtav1"),
-    ("SVTJPEGXS", "libsvtjpegxs"),
-    ("THEORA", "libtheora"),
-    ("TWOLAME", "libtwolame"),
-    ("UAVS3D", "libuavs3d"),
-    ("UTVIDEO", "libutvideo"),
-    ("VO_AACENC", "libvo-aacenc"),
-    ("VO_AMRWBENC", "libvo-amrwbenc"),
-    ("VORBIS", "libvorbis"),
-    ("VPX", "libvpx"),
-    ("VVENC", "libvvenc"),
-    ("WAVPACK", "libwavpack"),
-    ("WEBP", "libwebp"),
-    ("X264", "libx264"),
-    ("X265", "libx265"),
-    ("XEVE", "libxeve"),
-    ("XEVD", "libxevd"),
-    ("XAVS", "libxavs"),
-    ("XAVS2", "libxavs2"),
-    ("AVS", "libavs"),
-    ("XVID", "libxvid"),
-    // Protocols
-    ("SMBCLIENT", "libsmbclient"),
-    ("SSH", "libssh"),
-];
-
-fn build(out_dir: &Path, ffmpeg_version: &str) -> io::Result<PathBuf> {
-    let source_dir = out_dir.join(format!("ffmpeg-{ffmpeg_version}"));
-    let install_dir = out_dir.join("dist");
-    if install_dir.join("lib").join("libavutil.a").exists() {
-        rustc_link_extralibs(&source_dir);
-        return Ok(install_dir);
-    }
-
-    fetch(&source_dir, ffmpeg_version)?;
-
-    // Command's path is not relative to command's current_dir
-    let configure_path = source_dir.join("configure");
-    assert!(configure_path.exists());
-    let mut configure = Command::new(&configure_path);
-    configure.current_dir(&source_dir);
-
-    configure.arg(format!("--prefix={}", install_dir.to_string_lossy()));
-
-    if env::var("TARGET").unwrap() != env::var("HOST").unwrap() {
-        // Rust targets are subtly different than naming scheme for compiler prefixes.
-        // The cc crate has the messy logic of guessing a working prefix,
-        // and this is a messy way of reusing that logic.
-        let cc = cc::Build::new();
-        let compiler = cc.get_compiler();
-        let compiler = compiler.path().file_stem().unwrap().to_str().unwrap();
-        let suffix_pos = compiler.rfind('-').unwrap(); // cut off "-gcc"
-        let prefix = compiler[0..suffix_pos].trim_end_matches("-wr"); // "wr-c++" compiler
-
-        configure.arg(format!("--cross-prefix={}-", prefix));
-        configure.arg(format!(
-            "--arch={}",
-            env::var("CARGO_CFG_TARGET_ARCH").unwrap()
-        ));
-        configure.arg(format!(
-            "--target_os={}",
-            env::var("CARGO_CFG_TARGET_OS").unwrap()
-        ));
-    }
-
-    // control debug build
-    if env::var("DEBUG").is_ok() {
-        configure.arg("--enable-debug");
-        configure.arg("--disable-stripping");
-    } else {
-        configure.arg("--disable-debug");
-        configure.arg("--enable-stripping");
-    }
-
-    // make it static
-    configure.arg("--enable-static");
-    configure.arg("--disable-shared");
-
-    configure.arg("--enable-pic");
-
-    // stop autodetected libraries enabling themselves, causing linking errors
-    configure.arg("--disable-autodetect");
-
-    // do not build programs since we don't need them
-    configure.arg("--disable-programs");
-
-    // the binary using ffmpeg-sys must comply with GPL
-    configure.switch("BUILD_LICENSE_GPL", "gpl");
-
-    // the binary using ffmpeg-sys must comply with (L)GPLv3
-    configure.switch("BUILD_LICENSE_VERSION3", "version3");
-
-    // the binary using ffmpeg-sys cannot be redistributed
-    configure.switch("BUILD_LICENSE_NONFREE", "nonfree");
-
-    // configure building libraries based on features
-    for lib in LIBRARIES.iter().filter(|lib| lib.optional) {
-        configure.switch(&lib.name.to_uppercase(), lib.name);
-    }
-
-    // configure external libraries based on features
-    for (cargo_feat, option_name) in EXTERNAL_BUILD_LIBS {
-        configure.enable(&format!("BUILD_LIB_{cargo_feat}"), option_name);
-    }
-
-    configure.enable("BUILD_DRM", "libdrm");
-    configure.enable("BUILD_NVENC", "nvenc");
-    // configure misc build options
-    configure.enable("BUILD_PIC", "pic");
-
-    // run ./configure
-    let output = configure
-        .output()
-        .unwrap_or_else(|_| panic!("{:?} failed", configure));
-    if !output.status.success() {
-        println!("configure: {}", String::from_utf8_lossy(&output.stdout));
-
-        return Err(io::Error::other(
-            format!(
-                "configure failed {}",
-                String::from_utf8_lossy(&output.stderr)
-            ),
-        ));
-    }
-
-    let num_jobs = if let Ok(cpus) = std::thread::available_parallelism() {
-        cpus.to_string()
-    } else {
-        "1".to_string()
-    };
-
-    // run make
-    if !Command::new("make")
-        .arg(format!("-j{num_jobs}"))
-        .current_dir(&source_dir)
-        .status()?
-        .success()
-    {
-        return Err(io::Error::other("make failed"));
-    }
-
-    // run make install
-    if !Command::new("make")
-        .current_dir(&source_dir)
-        .arg("install")
-        .status()?
-        .success()
-    {
-        return Err(io::Error::other("make install failed"));
-    }
-
-    rustc_link_extralibs(&source_dir);
-    Ok(install_dir)
-}
-
-fn rustc_link_extralibs(source_dir: &Path) {
-    let config_mak = source_dir.join("ffbuild").join("config.mak");
-    let file = File::open(config_mak).unwrap();
-    let reader = BufReader::new(file);
-    let extra_libs = reader
-        .lines()
-        .find(|line| line.as_ref().unwrap().starts_with("EXTRALIBS"))
-        .map(|line| line.unwrap())
-        .unwrap();
-
-    let linker_args = extra_libs.split('=').next_back().unwrap().split(' ');
-    let include_libs = linker_args
-        .filter(|v| v.starts_with("-l"))
-        .map(|flag| &flag[2..]);
-
-    for lib in include_libs {
-        println!("cargo:rustc-link-lib={lib}");
-    }
 }
 
 #[cfg(not(target_env = "msvc"))]
@@ -679,6 +407,8 @@ fn try_vcpkg(statik: bool) -> Option<Vec<PathBuf>> {
 // add well known package manager lib paths us as homebrew (or macports)
 #[cfg(target_os = "macos")]
 fn add_pkg_config_path() {
+    use std::path::Path;
+
     let pc_path = pkg_config::get_variable("pkg-config", "pc_path").unwrap();
     // append M1 homebrew pkgconfig path
     let brew_pkgconfig = cfg!(target_arch = "aarch64")
@@ -695,20 +425,19 @@ fn add_pkg_config_path() {
 #[cfg(not(target_os = "macos"))]
 fn add_pkg_config_path() {}
 
-fn check_features(include_paths: &[PathBuf]) -> u64 {
+fn check_features(libraries: &[Library], include_paths: &[PathBuf]) -> u64 {
     let clang = clang::Clang::new().expect("Cannot find clang");
     let index = clang::Index::new(&clang, false, false);
 
     println!("loaded clang version: {}", clang::get_version());
 
-    let enabled_libraries = || LIBRARIES.iter().filter(|lib| lib.enabled());
-
     let mut code = String::new();
-    for lib in enabled_libraries() {
+    for lib in libraries {
         let _ = writeln!(code, "#include <lib{}/{}.h>", lib.name, lib.name);
     }
 
-    let mut features_defined_enabled = enabled_libraries()
+    let mut features_defined_enabled = libraries
+        .iter()
         .flat_map(|lib| lib.features)
         .map(|feature| {
             let feature_name = format!("FF_API_{}", feature.name);
@@ -723,7 +452,8 @@ fn check_features(include_paths: &[PathBuf]) -> u64 {
         })
         .collect::<HashMap<_, _>>();
 
-    let mut versions = enabled_libraries()
+    let mut versions = libraries
+        .iter()
         .map(|lib| (lib.name, (0, 0)))
         .collect::<HashMap<_, _>>();
 
@@ -787,7 +517,7 @@ fn check_features(include_paths: &[PathBuf]) -> u64 {
         }
     }
 
-    for lib in enabled_libraries() {
+    for lib in libraries {
         let ver = if let Some(v) = versions.get(&lib.name) {
             v
         } else {
@@ -846,9 +576,9 @@ fn check_features(include_paths: &[PathBuf]) -> u64 {
     lavc_version.0
 }
 
-fn link_to_libraries(statik: bool) {
+fn link_to_libraries(libraries: &[Library], statik: bool) {
     let ffmpeg_ty = if statik { "static" } else { "dylib" };
-    for lib in LIBRARIES.iter().filter(|lib| lib.enabled()) {
+    for lib in libraries {
         println!("cargo:rustc-link-lib={}={}", ffmpeg_ty, lib.name);
     }
     if cargo_feature_enabled("build_zlib") && cfg!(target_os = "linux") {
@@ -861,13 +591,28 @@ fn main() {
     let statik = cargo_feature_enabled("static");
     let ffmpeg_version = ffmpeg_version();
 
+    let all_libraries = [
+        Library::required("avutil", AVUTIL_FEATURES, AVUTIL_HEADERS, 57),
+        Library::optional("avcodec", AVCODEC_FEATURES, AVCODEC_HEADERS, 59),
+        Library::optional("avformat", AVFORMAT_FEATURES, AVFORMAT_HEADERS, 59),
+        Library::optional("avdevice", AVDEVICE_FEATURES, AVDEVICE_HEADERS, 59),
+        Library::optional("avfilter", AVFILTER_FEATURES, AVFILTER_HEADERS, 8),
+        Library::optional("swscale", SWSCALE_FEATURES, SWSCALE_HEADERS, 6),
+        Library::optional("swresample", SWRESAMPLE_FEATURES, SWRESAMPLE_HEADERS, 4),
+    ];
+
+    let enabled_libraries: Vec<_> = all_libraries
+        .into_iter()
+        .filter(|lib| lib.enabled())
+        .collect();
+
     let include_paths: Vec<PathBuf> = if cargo_feature_enabled("build") {
-        let install_dir = build(&out_dir, &ffmpeg_version).unwrap();
+        let install_dir = compile::build(&enabled_libraries, &out_dir, &ffmpeg_version).unwrap();
         println!(
             "cargo:rustc-link-search=native={}",
             install_dir.join("lib").to_string_lossy()
         );
-        link_to_libraries(statik);
+        link_to_libraries(&enabled_libraries, statik);
 
         vec![install_dir.join("include")]
     }
@@ -878,7 +623,7 @@ fn main() {
             "cargo:rustc-link-search=native={}",
             ffmpeg_dir.join("lib").to_string_lossy()
         );
-        link_to_libraries(statik);
+        link_to_libraries(&enabled_libraries, statik);
         vec![ffmpeg_dir.join("include")]
     } else if let Some(paths) = try_vcpkg(statik) {
         // vcpkg doesn't detect the "system" dependencies
@@ -904,7 +649,7 @@ fn main() {
         let mut pkgconfig = pkg_config::Config::new();
         pkgconfig.statik(statik);
 
-        for lib in LIBRARIES.iter().filter(|lib| lib.enabled()) {
+        for lib in &enabled_libraries {
             let _ = pkgconfig.probe(&lib.lib_name()).unwrap();
         }
 
@@ -935,11 +680,11 @@ fn main() {
         }
     }
 
-    check_features(&include_paths);
+    check_features(&enabled_libraries, &include_paths);
 
     let mut wrapper_h = String::with_capacity(2048);
 
-    for lib in LIBRARIES.iter().filter(|lib| lib.enabled()) {
+    for lib in &enabled_libraries {
         for header in lib.headers {
             add_include(&mut wrapper_h, lib, header).expect("failed to write to String");
         }

--- a/ffmpeg-sys-the-third/build/compile.rs
+++ b/ffmpeg-sys-the-third/build/compile.rs
@@ -230,30 +230,14 @@ pub fn build(libraries: &[Library], out_dir: &Path) -> io::Result<PathBuf> {
         )));
     }
 
-    let num_jobs = if let Ok(cpus) = std::thread::available_parallelism() {
-        cpus.to_string()
-    } else {
-        "1".to_string()
-    };
-
-    // run make
     if !Command::new("make")
-        .arg(format!("-j{num_jobs}"))
-        .current_dir(&source_dir)
-        .status()?
-        .success()
-    {
-        return Err(io::Error::new(io::ErrorKind::Other, "make failed"));
-    }
-
-    // run make install
-    if !Command::new("make")
-        .current_dir(&source_dir)
         .arg("install")
+        .env("MAKEFLAGS", env::var("CARGO_MAKEFLAGS").unwrap())
+        .current_dir(&source_dir)
         .status()?
         .success()
     {
-        return Err(io::Error::new(io::ErrorKind::Other, "make install failed"));
+        return Err(io::Error::other("make install failed"));
     }
 
     rustc_link_extralibs(&source_dir);

--- a/ffmpeg-sys-the-third/build/compile.rs
+++ b/ffmpeg-sys-the-third/build/compile.rs
@@ -216,8 +216,6 @@ pub fn build(libraries: &[Library], out_dir: &Path) -> io::Result<PathBuf> {
 
     configure.enable("BUILD_DRM", "libdrm");
     configure.enable("BUILD_NVENC", "nvenc");
-    // configure misc build options
-    configure.enable("BUILD_PIC", "pic");
 
     // run ./configure
     let output = configure.output()?;

--- a/ffmpeg-sys-the-third/build/compile.rs
+++ b/ffmpeg-sys-the-third/build/compile.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
 
 use crate::cargo_feature_enabled;
 use crate::Library;
@@ -79,6 +79,44 @@ static EXTERNAL_BUILD_LIBS: &[(&str, &str)] = &[
     ("SSH", "libssh"),
 ];
 
+const REPO_URL: &str = "https://github.com/FFmpeg/FFmpeg";
+
+fn get_newest_patch_version() -> String {
+    let crate_ffmpeg_version = env!("CARGO_PKG_VERSION")
+        .split_once("+ffmpeg-")
+        .expect("crate version follows v1.2.3+ffmpeg-4.5 format")
+        .1;
+
+    // The crate version usually doesn't reference patch releases, so
+    // see if there's a compatible patch (i.e. 8.0.3 for 8.0) in the remote repository.
+
+    let Output { status, stdout, .. } = Command::new("git")
+        .arg("ls-remote")
+        .arg("-q")
+        .arg("--tags")
+        .arg("--refs")
+        .arg(REPO_URL)
+        .arg(format!("n{}*", crate_ffmpeg_version))
+        .output()
+        .expect("can run git ls-remote");
+
+    assert!(
+        status.success(),
+        "git ls-remote returned non-zero exit code"
+    );
+
+    String::from_utf8(stdout)
+        .expect("git ls-remote output is utf8")
+        .lines()
+        // format follows <commit hash><TAB>refs/tags/n8.0
+        .filter_map(|line| line.split_once("refs/tags/n"))
+        .map(|(_hash, version)| version)
+        .filter(|ver| !ver.contains("-dev"))
+        .max() // lexicographic maximum is the highest version
+        .expect("matching non-dev tag exists")
+        .to_string()
+}
+
 fn fetch(source_dir: &Path, ffmpeg_version: &str) -> io::Result<()> {
     let _ = std::fs::remove_dir_all(source_dir);
     let status = Command::new("git")
@@ -86,7 +124,7 @@ fn fetch(source_dir: &Path, ffmpeg_version: &str) -> io::Result<()> {
         .arg("--depth=1")
         .arg("-b")
         .arg(format!("n{ffmpeg_version}"))
-        .arg("https://github.com/FFmpeg/FFmpeg")
+        .arg(REPO_URL)
         .arg(source_dir)
         .status()?;
 
@@ -97,7 +135,8 @@ fn fetch(source_dir: &Path, ffmpeg_version: &str) -> io::Result<()> {
     }
 }
 
-pub fn build(libraries: &[Library], out_dir: &Path, ffmpeg_version: &str) -> io::Result<PathBuf> {
+pub fn build(libraries: &[Library], out_dir: &Path) -> io::Result<PathBuf> {
+    let ffmpeg_version = get_newest_patch_version();
     let source_dir = out_dir.join(format!("ffmpeg-{ffmpeg_version}"));
     let install_dir = out_dir.join("dist");
     if install_dir.join("lib").join("libavutil.a").exists() {
@@ -105,7 +144,7 @@ pub fn build(libraries: &[Library], out_dir: &Path, ffmpeg_version: &str) -> io:
         return Ok(install_dir);
     }
 
-    fetch(&source_dir, ffmpeg_version)?;
+    fetch(&source_dir, &ffmpeg_version)?;
 
     // Explicitly enable building all libraries passed to this function
     let library_flags = libraries.iter().map(|lib| format!("--enable-{}", lib.name));

--- a/ffmpeg-sys-the-third/build/compile.rs
+++ b/ffmpeg-sys-the-third/build/compile.rs
@@ -1,0 +1,266 @@
+use std::env;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::cargo_feature_enabled;
+use crate::Library;
+
+// left side: cargo feature name ("CARGO_FEATURE_BUILD_LIB_{}")
+// right side: FFmpeg configure name ("--enable-{}")
+static EXTERNAL_BUILD_LIBS: &[(&str, &str)] = &[
+    // SSL
+    ("GNUTLS", "gnutls"),
+    ("OPENSSL", "openssl"),
+    // Filters
+    ("FONTCONFIG", "fontconfig"),
+    ("FREI0R", "frei0r"),
+    ("LADSPA", "ladspa"),
+    ("ASS", "libass"),
+    ("FREETYPE", "libfreetype"),
+    ("FRIBIDI", "libfribidi"),
+    ("OPENCV", "libopencv"),
+    ("VMAF", "libvmaf"),
+    // Encoders/decoders
+    ("AACPLUS", "libaacplus"),
+    ("CELT", "libcelt"),
+    ("CODEC2", "libcodec2"),
+    ("DAV1D", "libdav1d"),
+    ("DAVS2", "libdavs2"),
+    ("DCADEC", "libdcadec"),
+    ("FAAC", "libfaac"),
+    ("FDK_AAC", "libfdk-aac"),
+    ("GSM", "libgsm"),
+    ("ILBC", "libilbc"),
+    ("JXL", "libjxl"),
+    ("KVAZAAR", "libkvazaar"),
+    ("LC3", "liblc3"),
+    ("LCEVC_DEC", "liblcevc-dec"),
+    ("MP3LAME", "libmp3lame"),
+    ("MPEGHDEC", "libmpeghdec"),
+    ("OAPV", "liboapv"),
+    ("OPENCORE_AMRNB", "libopencore-amrnb"),
+    ("OPENCORE_AMRWB", "libopencore-amrwb"),
+    ("OPENH264", "libopenh264"),
+    ("OPENH265", "libopenh265"),
+    ("OPENJPEG", "libopenjpeg"),
+    ("OPENMPT", "libopenmpt"),
+    ("OPUS", "libopus"),
+    ("RAV1E", "librav1e"),
+    ("SCHROEDINGER", "libschroedinger"),
+    ("SHINE", "libshine"),
+    ("SNAPPY", "libsnappy"),
+    ("SPEEX", "libspeex"),
+    ("STAGEFRIGHT_H264", "libstagefright-h264"),
+    ("SVTAV1", "libsvtav1"),
+    ("SVTJPEGXS", "libsvtjpegxs"),
+    ("THEORA", "libtheora"),
+    ("TWOLAME", "libtwolame"),
+    ("UAVS3D", "libuavs3d"),
+    ("UTVIDEO", "libutvideo"),
+    ("VO_AACENC", "libvo-aacenc"),
+    ("VO_AMRWBENC", "libvo-amrwbenc"),
+    ("VORBIS", "libvorbis"),
+    ("VPX", "libvpx"),
+    ("VVENC", "libvvenc"),
+    ("WAVPACK", "libwavpack"),
+    ("WEBP", "libwebp"),
+    ("X264", "libx264"),
+    ("X265", "libx265"),
+    ("XEVE", "libxeve"),
+    ("XEVD", "libxevd"),
+    ("XAVS", "libxavs"),
+    ("XAVS2", "libxavs2"),
+    ("AVS", "libavs"),
+    ("XVID", "libxvid"),
+    // Protocols
+    ("SMBCLIENT", "libsmbclient"),
+    ("SSH", "libssh"),
+];
+
+fn fetch(source_dir: &Path, ffmpeg_version: &str) -> io::Result<()> {
+    let _ = std::fs::remove_dir_all(source_dir);
+    let status = Command::new("git")
+        .arg("clone")
+        .arg("--depth=1")
+        .arg("-b")
+        .arg(format!("n{ffmpeg_version}"))
+        .arg("https://github.com/FFmpeg/FFmpeg")
+        .arg(source_dir)
+        .status()?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other("fetch failed"))
+    }
+}
+
+pub fn build(libraries: &[Library], out_dir: &Path, ffmpeg_version: &str) -> io::Result<PathBuf> {
+    let source_dir = out_dir.join(format!("ffmpeg-{ffmpeg_version}"));
+    let install_dir = out_dir.join("dist");
+    if install_dir.join("lib").join("libavutil.a").exists() {
+        rustc_link_extralibs(&source_dir);
+        return Ok(install_dir);
+    }
+
+    fetch(&source_dir, ffmpeg_version)?;
+
+    // Explicitly enable building all libraries passed to this function
+    let library_flags = libraries.iter().map(|lib| format!("--enable-{}", lib.name));
+
+    // Command's path is not relative to command's current_dir
+    let configure_path = source_dir.join("configure");
+    assert!(configure_path.exists());
+    let mut configure = Command::new(configure_path);
+    configure.current_dir(&source_dir);
+
+    configure.arg(format!("--prefix={}", install_dir.to_string_lossy()));
+    configure.args(library_flags);
+
+    if env::var("TARGET").unwrap() != env::var("HOST").unwrap() {
+        // Rust targets are subtly different than naming scheme for compiler prefixes.
+        // The cc crate has the messy logic of guessing a working prefix,
+        // and this is a messy way of reusing that logic.
+        let cc = cc::Build::new();
+        let compiler = cc.get_compiler();
+        let compiler = compiler.path().file_stem().unwrap().to_str().unwrap();
+        let suffix_pos = compiler.rfind('-').unwrap(); // cut off "-gcc"
+        let prefix = compiler[0..suffix_pos].trim_end_matches("-wr"); // "wr-c++" compiler
+
+        configure.arg(format!("--cross-prefix={}-", prefix));
+        configure.arg(format!(
+            "--arch={}",
+            env::var("CARGO_CFG_TARGET_ARCH").unwrap()
+        ));
+        configure.arg(format!(
+            "--target_os={}",
+            env::var("CARGO_CFG_TARGET_OS").unwrap()
+        ));
+    }
+
+    // control debug build
+    if env::var("DEBUG").is_ok() {
+        configure.arg("--enable-debug");
+        configure.arg("--disable-stripping");
+    } else {
+        configure.arg("--disable-debug");
+        configure.arg("--enable-stripping");
+    }
+
+    // make it static
+    configure.arg("--enable-static");
+    configure.arg("--disable-shared");
+
+    configure.arg("--enable-pic");
+
+    // stop autodetected libraries enabling themselves, causing linking errors
+    configure.arg("--disable-autodetect");
+
+    // do not build programs since we don't need them
+    configure.arg("--disable-programs");
+
+    // the binary using ffmpeg-sys must comply with GPL
+    configure.switch("BUILD_LICENSE_GPL", "gpl");
+
+    // the binary using ffmpeg-sys must comply with (L)GPLv3
+    configure.switch("BUILD_LICENSE_VERSION3", "version3");
+
+    // the binary using ffmpeg-sys cannot be redistributed
+    configure.switch("BUILD_LICENSE_NONFREE", "nonfree");
+
+    // configure external libraries based on features
+    for (cargo_feat, option_name) in EXTERNAL_BUILD_LIBS {
+        configure.enable(&format!("BUILD_LIB_{cargo_feat}"), option_name);
+    }
+
+    configure.enable("BUILD_DRM", "libdrm");
+    configure.enable("BUILD_NVENC", "nvenc");
+    // configure misc build options
+    configure.enable("BUILD_PIC", "pic");
+
+    // run ./configure
+    let output = configure.output()?;
+    if !output.status.success() {
+        println!("configure: {}", String::from_utf8_lossy(&output.stdout));
+
+        return Err(io::Error::other(format!(
+            "configure failed {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    let num_jobs = if let Ok(cpus) = std::thread::available_parallelism() {
+        cpus.to_string()
+    } else {
+        "1".to_string()
+    };
+
+    // run make
+    if !Command::new("make")
+        .arg(format!("-j{num_jobs}"))
+        .current_dir(&source_dir)
+        .status()?
+        .success()
+    {
+        return Err(io::Error::new(io::ErrorKind::Other, "make failed"));
+    }
+
+    // run make install
+    if !Command::new("make")
+        .current_dir(&source_dir)
+        .arg("install")
+        .status()?
+        .success()
+    {
+        return Err(io::Error::new(io::ErrorKind::Other, "make install failed"));
+    }
+
+    rustc_link_extralibs(&source_dir);
+    Ok(install_dir)
+}
+
+fn rustc_link_extralibs(source_dir: &Path) {
+    let config_mak = source_dir.join("ffbuild").join("config.mak");
+    let file = File::open(config_mak).unwrap();
+    let reader = BufReader::new(file);
+    let extra_libs = reader
+        .lines()
+        .map(|line| line.expect("config.mak contains valid utf8"))
+        .find(|line| line.starts_with("EXTRALIBS="))
+        .expect("config.mak contains EXTRALIBS= line");
+
+    let include_libs = extra_libs
+        .strip_prefix("EXTRALIBS=")
+        .unwrap()
+        .split_ascii_whitespace()
+        .filter_map(|v| v.strip_prefix("-l"));
+
+    for lib in include_libs {
+        println!("cargo::rustc-link-lib={lib}");
+    }
+}
+
+trait FFmpegConfigure {
+    fn switch(&mut self, feature: &str, option_name: &str);
+    fn enable(&mut self, feature: &str, option_name: &str);
+}
+
+impl FFmpegConfigure for Command {
+    fn switch(&mut self, feature: &str, option_name: &str) {
+        let arg = if cargo_feature_enabled(feature) {
+            format!("--enable-{option_name}")
+        } else {
+            format!("--disable-{option_name}")
+        };
+
+        self.arg(arg);
+    }
+
+    fn enable(&mut self, feature: &str, option_name: &str) {
+        if cargo_feature_enabled(feature) {
+            self.arg(format!("--enable-{option_name}"));
+        }
+    }
+}


### PR DESCRIPTION
- Create a "wrapper.h" pseudo header (in-memory) that includes the libav/libsw headers transitively. This is what the [bindgen guide](https://rust-lang.github.io/rust-bindgen/tutorial-2.html) recommends and removes the needs for manual `search_include` (clang can do this for us)
- move the build feature into its own file and add a few features
  - take FFmpeg version from the crate version and look for the newest patch instead of just building the base version
  - pass jobserver info from cargo to make. before: `cargo build -j4` would use 4 cores to build the Rust code but would use everything for the FFmpeg build. now the FFmpeg build respects the job setting from cargo
  - always enable PIC. also remove the `build-pic` feature
- move from `cargo:` to `cargo::` build script output
- various small modernizations

Still have a few ideas on how to improve the build process but this is the obvious stuff out of the way.