### PR TITLE
refactor: remove unsafe from safe Rust functions

### DIFF
--- a/ffmpeg-sys-the-third/src/avutil/rational.rs
+++ b/ffmpeg-sys-the-third/src/avutil/rational.rs
@@ -1,13 +1,11 @@
 use crate::AVRational;
 use libc::{c_double, c_int};
 
-#[inline(always)]
-pub unsafe fn av_make_q(num: c_int, den: c_int) -> AVRational {
+pub const fn av_make_q(num: c_int, den: c_int) -> AVRational {
     AVRational { num, den }
 }
 
-#[inline(always)]
-pub unsafe fn av_cmp_q(a: AVRational, b: AVRational) -> c_int {
+pub fn av_cmp_q(a: AVRational, b: AVRational) -> c_int {
     let tmp = i64::from(a.num) * i64::from(b.den) - i64::from(b.num) * i64::from(a.den);
 
     if tmp != 0 {
@@ -15,19 +13,17 @@ pub unsafe fn av_cmp_q(a: AVRational, b: AVRational) -> c_int {
     } else if b.den != 0 && a.den != 0 {
         0
     } else if a.num != 0 && b.num != 0 {
-        ((i64::from(a.num) >> 31) - (i64::from(b.num) >> 31)) as c_int
+        ((a.num >> 31) - (b.num >> 31)) as c_int
     } else {
         c_int::MIN
     }
 }
 
-#[inline(always)]
-pub unsafe fn av_q2d(a: AVRational) -> c_double {
+pub fn av_q2d(a: AVRational) -> c_double {
     f64::from(a.num) / f64::from(a.den)
 }
 
-#[inline(always)]
-pub unsafe fn av_inv_q(q: AVRational) -> AVRational {
+pub const fn av_inv_q(q: AVRational) -> AVRational {
     AVRational {
         num: q.den,
         den: q.num,

--- a/src/util/rational.rs
+++ b/src/util/rational.rs
@@ -56,7 +56,7 @@ impl Rational {
 
     #[inline]
     pub fn invert(&self) -> Rational {
-        unsafe { Rational::from(av_inv_q((*self).into())) }
+        Rational::from(av_inv_q((*self).into()))
     }
 }
 
@@ -87,7 +87,7 @@ impl From<f64> for Rational {
 impl From<Rational> for f64 {
     #[inline]
     fn from(value: Rational) -> f64 {
-        unsafe { av_q2d(value.into()) }
+        av_q2d(value.into())
     }
 }
 
@@ -126,14 +126,12 @@ impl Eq for Rational {}
 impl PartialOrd for Rational {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        unsafe {
-            match av_cmp_q((*self).into(), (*other).into()) {
-                0 => Some(Ordering::Equal),
-                1 => Some(Ordering::Greater),
-                -1 => Some(Ordering::Less),
+        match av_cmp_q((*self).into(), (*other).into()) {
+            0 => Some(Ordering::Equal),
+            1 => Some(Ordering::Greater),
+            -1 => Some(Ordering::Less),
 
-                _ => None,
-            }
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
No reason to have these be unsafe.