### PR TITLE
refactor!: simplify Rect & make safer

### DIFF
--- a/src/codec/subtitle/mod.rs
+++ b/src/codec/subtitle/mod.rs
@@ -2,16 +2,17 @@ pub mod flag;
 pub use self::flag::Flags;
 
 mod rect;
-pub use self::rect::{Ass, Bitmap, Rect, Text};
-
+mod rect_common;
+pub use self::rect::RectRef;
 mod rect_mut;
-pub use self::rect_mut::{AssMut, BitmapMut, RectMut, TextMut};
+pub use self::rect_mut::RectMut;
 
-use std::marker::PhantomData;
+use std::iter::FusedIterator;
 use std::mem;
+use std::ptr::NonNull;
 
 use crate::ffi::*;
-use libc::{c_uint, size_t};
+use libc::size_t;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
@@ -97,121 +98,151 @@ impl Subtitle {
     }
 
     pub fn rects(&self) -> RectIter<'_> {
-        RectIter::new(&self.0)
-    }
-
-    pub fn rects_mut(&'_ mut self) -> RectMutIter<'_> {
-        RectMutIter::new(&mut self.0)
-    }
-
-    pub fn add_rect(&mut self, kind: Type) -> RectMut<'_> {
         unsafe {
-            self.0.num_rects += 1;
-            self.0.rects = av_realloc(
+            let ptrs = if (*self.as_ptr()).rects.is_null() {
+                &[]
+            } else {
+                std::slice::from_raw_parts(
+                    (*self.as_ptr()).rects,
+                    (*self.as_ptr()).num_rects as usize,
+                )
+            };
+
+            RectIter::from_av_rects(ptrs)
+        }
+    }
+
+    pub fn rects_mut(&mut self) -> RectMutIter<'_> {
+        unsafe {
+            let ptrs = if (*self.as_ptr()).rects.is_null() {
+                &mut []
+            } else {
+                std::slice::from_raw_parts_mut(
+                    (*self.as_ptr()).rects,
+                    (*self.as_ptr()).num_rects as usize,
+                )
+            };
+
+            RectMutIter::from_av_rects(ptrs)
+        }
+    }
+
+    pub fn add_rect(&mut self, kind: Type) -> Option<RectMut<'_>> {
+        unsafe {
+            let new_sz = 1 + self.0.num_rects as usize;
+            let new_ptr = av_realloc(
                 self.0.rects as *mut _,
-                (size_of::<*const AVSubtitleRect>() * self.0.num_rects as usize) as size_t,
-            ) as *mut _;
+                size_of::<*const AVSubtitleRect>() * new_sz,
+            ) as *mut *mut AVSubtitleRect;
+
+            if new_ptr.is_null() {
+                return None;
+            }
+
+            self.0.rects = new_ptr;
+            self.0.num_rects = new_sz as u32;
 
             let rect = av_mallocz(size_of::<AVSubtitleRect>() as size_t) as *mut AVSubtitleRect;
-            (*rect).type_ = kind.into();
+            let mut rect = NonNull::new(rect)?;
 
-            *self.0.rects.offset((self.0.num_rects - 1) as isize) = rect;
+            rect.as_mut().type_ = kind.into();
+            *self.0.rects.add(new_sz - 1) = rect.as_ptr();
 
-            RectMut::wrap(rect)
+            Some(RectMut::from_ptr(rect))
         }
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct RectIter<'s> {
+    raw_iter: std::slice::Iter<'s, *mut AVSubtitleRect>,
+}
+
+impl<'s> RectIter<'s> {
+    pub fn from_av_rects(rects: &'s [*mut AVSubtitleRect]) -> Self {
+        Self {
+            raw_iter: rects.iter(),
+        }
+    }
+}
+
+impl<'s> Iterator for RectIter<'s> {
+    type Item = RectRef<'s>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            // SAFETY: Lifetime is bounded by Self::Item (= 's)
+            self.raw_iter
+                .next()
+                .map(|&ptr| RectRef::from_ptr(NonNull::new(ptr).expect("ptr is non-null")))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.raw_iter.size_hint()
+    }
+}
+
+impl<'s> DoubleEndedIterator for RectIter<'s> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        unsafe {
+            // SAFETY: Lifetime is bounded by Self::Item (= 's)
+            self.raw_iter
+                .next_back()
+                .map(|&ptr| RectRef::from_ptr(NonNull::new(ptr).expect("ptr is non-null")))
+        }
+    }
+}
+
+impl<'s> ExactSizeIterator for RectIter<'s> {}
+impl<'s> FusedIterator for RectIter<'s> {}
+
+#[derive(Debug)]
+pub struct RectMutIter<'s> {
+    raw_iter: std::slice::IterMut<'s, *mut AVSubtitleRect>,
+}
+
+impl<'s> RectMutIter<'s> {
+    pub fn from_av_rects(rects: &'s mut [*mut AVSubtitleRect]) -> Self {
+        Self {
+            raw_iter: rects.iter_mut(),
+        }
+    }
+}
+
+impl<'s> Iterator for RectMutIter<'s> {
+    type Item = RectMut<'s>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            // SAFETY: Lifetime is bounded by Self::Item (= 's)
+            self.raw_iter
+                .next()
+                .map(|&mut ptr| RectMut::from_ptr(NonNull::new(ptr).expect("ptr is non-null")))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.raw_iter.size_hint()
+    }
+}
+
+impl<'s> DoubleEndedIterator for RectMutIter<'s> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        unsafe {
+            // SAFETY: Lifetime is bounded by Self::Item (= 's)
+            self.raw_iter
+                .next_back()
+                .map(|&mut ptr| RectMut::from_ptr(NonNull::new(ptr).expect("ptr is non-null")))
+        }
+    }
+}
+
+impl<'s> ExactSizeIterator for RectMutIter<'s> {}
+impl<'s> FusedIterator for RectMutIter<'s> {}
 
 impl Default for Subtitle {
     fn default() -> Self {
         Self::new()
     }
 }
-
-pub struct RectIter<'a> {
-    ptr: *const AVSubtitle,
-    cur: c_uint,
-
-    _marker: PhantomData<&'a Subtitle>,
-}
-
-impl<'a> RectIter<'a> {
-    pub fn new(ptr: *const AVSubtitle) -> Self {
-        RectIter {
-            ptr,
-            cur: 0,
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<'a> Iterator for RectIter<'a> {
-    type Item = Rect<'a>;
-
-    fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-        unsafe {
-            if self.cur >= (*self.ptr).num_rects {
-                None
-            } else {
-                self.cur += 1;
-                Some(Rect::wrap(
-                    *(*self.ptr).rects.offset((self.cur - 1) as isize),
-                ))
-            }
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        unsafe {
-            let length = (*self.ptr).num_rects as usize;
-
-            (length - self.cur as usize, Some(length - self.cur as usize))
-        }
-    }
-}
-
-impl<'a> ExactSizeIterator for RectIter<'a> {}
-
-pub struct RectMutIter<'a> {
-    ptr: *mut AVSubtitle,
-    cur: c_uint,
-
-    _marker: PhantomData<&'a Subtitle>,
-}
-
-impl<'a> RectMutIter<'a> {
-    pub fn new(ptr: *mut AVSubtitle) -> Self {
-        RectMutIter {
-            ptr,
-            cur: 0,
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<'a> Iterator for RectMutIter<'a> {
-    type Item = RectMut<'a>;
-
-    fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-        unsafe {
-            if self.cur >= (*self.ptr).num_rects {
-                None
-            } else {
-                self.cur += 1;
-                Some(RectMut::wrap(
-                    *(*self.ptr).rects.offset((self.cur - 1) as isize),
-                ))
-            }
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        unsafe {
-            let length = (*self.ptr).num_rects as usize;
-
-            (length - self.cur as usize, Some(length - self.cur as usize))
-        }
-    }
-}
-
-impl<'a> ExactSizeIterator for RectMutIter<'a> {}

--- a/src/codec/subtitle/rect.rs
+++ b/src/codec/subtitle/rect.rs
@@ -1,136 +1,29 @@
 use std::marker::PhantomData;
+use std::ptr::NonNull;
 
-use super::{Flags, Type};
+use super::Subtitle;
 use crate::ffi::*;
-use crate::utils;
+use crate::AsPtr;
 
-pub enum Rect<'a> {
-    None(*const AVSubtitleRect),
-    Bitmap(Bitmap<'a>),
-    Text(Text<'a>),
-    Ass(Ass<'a>),
+pub struct RectRef<'s> {
+    ptr: NonNull<AVSubtitleRect>,
+    _marker: PhantomData<&'s Subtitle>,
 }
 
-impl<'a> Rect<'a> {
-    pub unsafe fn wrap(ptr: *const AVSubtitleRect) -> Self {
-        match Type::from((*ptr).type_) {
-            Type::None => Rect::None(ptr),
-            Type::Bitmap => Rect::Bitmap(Bitmap::wrap(ptr)),
-            Type::Text => Rect::Text(Text::wrap(ptr)),
-            Type::Ass => Rect::Ass(Ass::wrap(ptr)),
-        }
-    }
-
-    pub unsafe fn as_ptr(&self) -> *const AVSubtitleRect {
-        match *self {
-            Rect::None(ptr) => ptr,
-            Rect::Bitmap(ref b) => b.as_ptr(),
-            Rect::Text(ref t) => t.as_ptr(),
-            Rect::Ass(ref a) => a.as_ptr(),
-        }
-    }
-}
-
-impl<'a> Rect<'a> {
-    pub fn flags(&self) -> Flags {
-        unsafe {
-            Flags::from_bits_truncate(match *self {
-                Rect::None(ptr) => (*ptr).flags,
-                Rect::Bitmap(ref b) => (*b.as_ptr()).flags,
-                Rect::Text(ref t) => (*t.as_ptr()).flags,
-                Rect::Ass(ref a) => (*a.as_ptr()).flags,
-            })
-        }
-    }
-}
-
-pub struct Bitmap<'a> {
-    ptr: *const AVSubtitleRect,
-
-    _marker: PhantomData<&'a ()>,
-}
-
-impl<'a> Bitmap<'a> {
-    pub unsafe fn wrap(ptr: *const AVSubtitleRect) -> Self {
-        Bitmap {
+impl<'s> RectRef<'s> {
+    /// # Safety
+    /// `ptr` must be a valid pointer to an [`AVSubtitleRect`].
+    /// Ensure that the returned lifetime is correctly bounded.
+    pub unsafe fn from_ptr(ptr: NonNull<AVSubtitleRect>) -> Self {
+        Self {
             ptr,
             _marker: PhantomData,
         }
     }
-
-    pub unsafe fn as_ptr(&self) -> *const AVSubtitleRect {
-        self.ptr
-    }
 }
 
-impl<'a> Bitmap<'a> {
-    pub fn x(&self) -> usize {
-        unsafe { (*self.as_ptr()).x as usize }
-    }
-
-    pub fn y(&self) -> usize {
-        unsafe { (*self.as_ptr()).y as usize }
-    }
-
-    pub fn width(&self) -> u32 {
-        unsafe { (*self.as_ptr()).w as u32 }
-    }
-
-    pub fn height(&self) -> u32 {
-        unsafe { (*self.as_ptr()).h as u32 }
-    }
-
-    pub fn colors(&self) -> usize {
-        unsafe { (*self.as_ptr()).nb_colors as usize }
-    }
-}
-
-pub struct Text<'a> {
-    ptr: *const AVSubtitleRect,
-
-    _marker: PhantomData<&'a ()>,
-}
-
-impl<'a> Text<'a> {
-    pub unsafe fn wrap(ptr: *const AVSubtitleRect) -> Self {
-        Text {
-            ptr,
-            _marker: PhantomData,
-        }
-    }
-
-    pub unsafe fn as_ptr(&self) -> *const AVSubtitleRect {
-        self.ptr
-    }
-}
-
-impl<'a> Text<'a> {
-    pub fn get(&self) -> &str {
-        unsafe { utils::str_from_c_ptr((*self.as_ptr()).text) }
-    }
-}
-
-pub struct Ass<'a> {
-    ptr: *const AVSubtitleRect,
-
-    _marker: PhantomData<&'a ()>,
-}
-
-impl<'a> Ass<'a> {
-    pub unsafe fn wrap(ptr: *const AVSubtitleRect) -> Self {
-        Ass {
-            ptr,
-            _marker: PhantomData,
-        }
-    }
-
-    pub unsafe fn as_ptr(&self) -> *const AVSubtitleRect {
-        self.ptr
-    }
-}
-
-impl<'a> Ass<'a> {
-    pub fn get(&self) -> &str {
-        unsafe { utils::str_from_c_ptr((*self.as_ptr()).ass) }
+impl<'s> AsPtr<AVSubtitleRect> for RectRef<'s> {
+    fn as_ptr(&self) -> *const AVSubtitleRect {
+        self.ptr.as_ptr()
     }
 }

--- a/src/codec/subtitle/rect_common.rs
+++ b/src/codec/subtitle/rect_common.rs
@@ -1,0 +1,46 @@
+use crate::macros::impl_for_many;
+
+use super::{Flags, RectMut, RectRef, Type};
+use crate::utils;
+use crate::AsPtr;
+
+impl_for_many! {
+    impl for RectRef<'s>, RectMut<'s> {
+        pub fn kind(&self) -> Type {
+            unsafe { (*self.as_ptr()).type_.into() }
+        }
+
+        pub fn flags(&self) -> Flags {
+            let flags = unsafe { (*self.as_ptr()).flags };
+            Flags::from_bits_retain(flags)
+        }
+
+        pub fn x(&self) -> usize {
+            unsafe { (*self.as_ptr()).x as usize }
+        }
+
+        pub fn y(&self) -> usize {
+            unsafe { (*self.as_ptr()).y as usize }
+        }
+
+        pub fn width(&self) -> u32 {
+            unsafe { (*self.as_ptr()).w as u32 }
+        }
+
+        pub fn height(&self) -> u32 {
+            unsafe { (*self.as_ptr()).h as u32 }
+        }
+
+        pub fn colors(&self) -> usize {
+            unsafe { (*self.as_ptr()).nb_colors as usize }
+        }
+
+        pub fn text(&self) -> Option<&str> {
+            unsafe { utils::optional_str_from_c_ptr((*self.as_ptr()).text) }
+        }
+
+        pub fn ass(&self) -> Option<&str> {
+            unsafe { utils::optional_str_from_c_ptr((*self.as_ptr()).ass) }
+        }
+    }
+}

--- a/src/codec/subtitle/rect_mut.rs
+++ b/src/codec/subtitle/rect_mut.rs
@@ -1,76 +1,38 @@
-use std::ffi::CString;
-use std::ops::Deref;
-
-use super::{Ass, Bitmap, Flags, Text, Type};
-use crate::ffi::*;
 use libc::c_int;
+use std::ffi::CString;
+use std::marker::PhantomData;
+use std::ptr::NonNull;
 
-pub enum RectMut<'a> {
-    None(*mut AVSubtitleRect),
-    Bitmap(BitmapMut<'a>),
-    Text(TextMut<'a>),
-    Ass(AssMut<'a>),
+use super::{Flags, RectRef, Subtitle};
+use crate::ffi::*;
+use crate::{AsMutPtr, AsPtr};
+
+pub struct RectMut<'s> {
+    ptr: NonNull<AVSubtitleRect>,
+    _marker: PhantomData<&'s mut Subtitle>,
 }
 
-impl<'a> RectMut<'a> {
-    pub unsafe fn wrap(ptr: *mut AVSubtitleRect) -> Self {
-        match Type::from((*ptr).type_) {
-            Type::None => RectMut::None(ptr),
-            Type::Bitmap => RectMut::Bitmap(BitmapMut::wrap(ptr)),
-            Type::Text => RectMut::Text(TextMut::wrap(ptr)),
-            Type::Ass => RectMut::Ass(AssMut::wrap(ptr)),
+impl<'s> RectMut<'s> {
+    /// # Safety
+    /// `ptr` must be a valid pointer to an [`AVSubtitleRect`].
+    /// Ensure that the returned lifetime is correctly bounded.
+    pub unsafe fn from_ptr(ptr: NonNull<AVSubtitleRect>) -> Self {
+        Self {
+            ptr,
+            _marker: PhantomData,
         }
     }
 
-    pub unsafe fn as_ptr(&self) -> *const AVSubtitleRect {
-        match *self {
-            RectMut::None(ptr) => ptr as *const _,
-            RectMut::Bitmap(ref b) => b.as_ptr(),
-            RectMut::Text(ref t) => t.as_ptr(),
-            RectMut::Ass(ref a) => a.as_ptr(),
-        }
+    pub fn as_ref(&self) -> RectRef<'s> {
+        unsafe { RectRef::from_ptr(self.ptr) }
     }
 
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut AVSubtitleRect {
-        match *self {
-            RectMut::None(ptr) => ptr,
-            RectMut::Bitmap(ref mut b) => b.as_mut_ptr(),
-            RectMut::Text(ref mut t) => t.as_mut_ptr(),
-            RectMut::Ass(ref mut a) => a.as_mut_ptr(),
-        }
-    }
-}
-
-impl<'a> RectMut<'a> {
-    pub fn flags(&self) -> Flags {
+    pub fn set_flags(&mut self, flags: Flags) {
         unsafe {
-            Flags::from_bits_truncate(match *self {
-                RectMut::None(ptr) => (*ptr).flags,
-                RectMut::Bitmap(ref b) => (*b.as_ptr()).flags,
-                RectMut::Text(ref t) => (*t.as_ptr()).flags,
-                RectMut::Ass(ref a) => (*a.as_ptr()).flags,
-            })
-        }
-    }
-}
-
-pub struct BitmapMut<'a> {
-    immutable: Bitmap<'a>,
-}
-
-impl<'a> BitmapMut<'a> {
-    pub unsafe fn wrap(ptr: *mut AVSubtitleRect) -> Self {
-        BitmapMut {
-            immutable: Bitmap::wrap(ptr as *const _),
+            (*self.as_mut_ptr()).flags = flags.bits();
         }
     }
 
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut AVSubtitleRect {
-        self.as_ptr() as *mut _
-    }
-}
-
-impl<'a> BitmapMut<'a> {
     pub fn set_x(&mut self, value: usize) {
         unsafe {
             (*self.as_mut_ptr()).x = value as c_int;
@@ -100,68 +62,16 @@ impl<'a> BitmapMut<'a> {
             (*self.as_mut_ptr()).nb_colors = value as c_int;
         }
     }
-}
 
-impl<'a> Deref for BitmapMut<'a> {
-    type Target = Bitmap<'a>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.immutable
-    }
-}
-
-pub struct TextMut<'a> {
-    immutable: Text<'a>,
-}
-
-impl<'a> TextMut<'a> {
-    pub unsafe fn wrap(ptr: *mut AVSubtitleRect) -> Self {
-        TextMut {
-            immutable: Text::wrap(ptr as *const _),
-        }
-    }
-
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut AVSubtitleRect {
-        self.as_ptr() as *mut _
-    }
-}
-
-impl<'a> TextMut<'a> {
-    pub fn set(&mut self, value: &str) {
+    pub fn set_text(&mut self, value: &str) {
         let value = CString::new(value).unwrap();
 
         unsafe {
             (*self.as_mut_ptr()).text = av_strdup(value.as_ptr());
         }
     }
-}
 
-impl<'a> Deref for TextMut<'a> {
-    type Target = Text<'a>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.immutable
-    }
-}
-
-pub struct AssMut<'a> {
-    immutable: Ass<'a>,
-}
-
-impl<'a> AssMut<'a> {
-    pub unsafe fn wrap(ptr: *mut AVSubtitleRect) -> Self {
-        AssMut {
-            immutable: Ass::wrap(ptr),
-        }
-    }
-
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut AVSubtitleRect {
-        self.as_ptr() as *mut _
-    }
-}
-
-impl<'a> AssMut<'a> {
-    pub fn set(&mut self, value: &str) {
+    pub fn set_ass(&mut self, value: &str) {
         let value = CString::new(value).unwrap();
 
         unsafe {
@@ -170,10 +80,14 @@ impl<'a> AssMut<'a> {
     }
 }
 
-impl<'a> Deref for AssMut<'a> {
-    type Target = Ass<'a>;
+impl<'s> AsPtr<AVSubtitleRect> for RectMut<'s> {
+    fn as_ptr(&self) -> *const AVSubtitleRect {
+        self.ptr.as_ptr()
+    }
+}
 
-    fn deref(&self) -> &Self::Target {
-        &self.immutable
+impl<'s> AsMutPtr<AVSubtitleRect> for RectMut<'s> {
+    fn as_mut_ptr(&mut self) -> *mut AVSubtitleRect {
+        self.ptr.as_ptr()
     }
 }


### PR DESCRIPTION
Noticed this while going through some of the newer lints. I don't think it's too bad to just give unfiltered access to the struct fields of `AVSubtitleRect` without the enclosing enum.

There were some alloc calls without null checks so I added those too.