### PR TITLE
fix: retain FFmpeg header doc comments

### DIFF
--- a/ffmpeg-sys-the-third/build.rs
+++ b/ffmpeg-sys-the-third/build.rs
@@ -808,6 +808,8 @@ fn main() {
     };
 
     bindgen::Builder::default()
+        .clang_arg("-fretain-comments-from-system-headers")
+        .clang_arg("-fparse-all-comments")
         .clang_args(clang_includes)
         .ctypes_prefix("libc")
         // Not trivially copyable


### PR DESCRIPTION
# fix: retain FFmpeg header doc comments

## Summary

Bindgen discarded FFmpeg header documentation because clang was not instructed to retain and parse comments from system headers. Configure the binding generator with the required clang flags so generated Rust bindings include those doc comments.

Fixes #151

## Changes

- Retain and parse comments from FFmpeg system headers during bindgen generation.

## Testing

- `sandbox-run "cargo fmt --check --manifest-path ffmpeg-sys-the-third/Cargo.toml && cargo clippy --manifest-path ffmpeg-sys-the-third/Cargo.toml --all-targets"` (could not run: the sandbox image does not provide `cargo`)
- `sandbox-run "clang --version"` (could not run: the sandbox image does not provide `clang`)
- `git diff --check` (passed before commit)

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
